### PR TITLE
Support `identify` method directly on Application

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "testem ci"
   },
   "dependencies": {
-    "@glimmer/di": "^0.1.6",
+    "@glimmer/di": "^0.1.7",
     "@glimmer/util": "^0.21.0"
   },
   "devDependencies": {

--- a/src/application.ts
+++ b/src/application.ts
@@ -73,6 +73,10 @@ export default class Application implements Owner {
     this._registry.registerInjection(normalizedSpecifier, property, normalizedInjection);
   }
 
+  identify(specifier: string, referrer?: string): string {
+    return this._toAbsoluteSpecifier(specifier, referrer);
+  }
+
   factoryFor(specifier: string, referrer?: string): Factory<any> {
     let absoluteSpecifier = this._toAbsoluteSpecifier(specifier, referrer);
     return this._container.factoryFor(absoluteSpecifier);

--- a/test/application-container-test.ts
+++ b/test/application-container-test.ts
@@ -5,6 +5,27 @@ const { module, test } = QUnit;
 
 module('Application - Container interface');
 
+test('#identify - returns an absolute specifier unchanged', function(assert) {
+  let app = new Application();
+  let absSpecifier = 'component:/app/components/date-picker';
+  assert.equal(app.identify(absSpecifier), absSpecifier, 'specifier was returned unchanged');
+});
+
+test('#identify - uses a resolver to convert a relative specifier to an absolute specifier', function(assert) {
+  assert.expect(2);
+
+  class FakeResolver implements Resolver {
+    identify(specifier: string, referrer?: string) {
+      assert.equal(specifier, 'component:date-picker', 'FakeResolver#identify was invoked');
+      return 'component:/app/components/date-picker';
+    }
+  }
+  let resolver = new FakeResolver();
+  let app = new Application(resolver);
+  let specifier = 'component:date-picker';
+  assert.equal(app.identify(specifier, 'component:/app/components/form-controls'), 'component:/app/components/date-picker', 'absolute specifier was returned');
+});
+
 test('#factoryFor - returns a registered factory', function(assert) {
   class DatePicker {
     static create() { return { foo: 'bar' }; }


### PR DESCRIPTION
`identify` is a new method required on the `Owner` interface, 
introduced in @glimmer/di 0.1.7.