### PR TITLE
Registry access refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@glimmer/component": "^0.1.0",
-    "@glimmer/di": "^0.1.7",
+    "@glimmer/di": "^0.1.8",
     "@glimmer/util": "^0.21.0"
   },
   "devDependencies": {

--- a/src/application-registry.ts
+++ b/src/application-registry.ts
@@ -1,0 +1,79 @@
+import {
+  Registry,
+  RegistryAccessor,
+  RegistrationOptions,
+  Injection,
+  Resolver
+} from '@glimmer/di';
+
+function isTypeSpecifier(specifier: string) {
+  return specifier.indexOf(':') === -1;
+}
+
+export default class ApplicationRegistry implements RegistryAccessor {
+  private _registry: Registry;
+  private _resolver: Resolver;
+
+  constructor(registry: Registry, resolver: Resolver) {
+    this._registry = registry;
+    this._resolver = resolver;
+  }
+
+  register(specifier: string, factory: any, options?: RegistrationOptions): void {
+    let normalizedSpecifier = this._toAbsoluteSpecifier(specifier);
+    this._registry.register(normalizedSpecifier, factory, options);
+  }
+
+  registration(specifier: string): any {
+    let normalizedSpecifier = this._toAbsoluteSpecifier(specifier);
+    return this._registry.registration(normalizedSpecifier);
+  }
+
+  unregister(specifier: string) {
+    let normalizedSpecifier = this._toAbsoluteSpecifier(specifier);
+    this._registry.unregister(normalizedSpecifier);
+  }
+
+  registerOption(specifier: string, option: string, value: any): void {
+    let normalizedSpecifier = this._toAbsoluteOrTypeSpecifier(specifier);
+    this._registry.registerOption(normalizedSpecifier, option, value);
+  }
+
+  registeredOption(specifier: string, option: string): any {
+    let normalizedSpecifier = this._toAbsoluteOrTypeSpecifier(specifier);
+    return this._registry.registeredOption(normalizedSpecifier, option);
+  }
+
+  registeredOptions(specifier: string): any {
+    let normalizedSpecifier = this._toAbsoluteOrTypeSpecifier(specifier);
+    return this._registry.registeredOptions(normalizedSpecifier);
+  }
+
+  unregisterOption(specifier: string, option: string): void {
+    let normalizedSpecifier = this._toAbsoluteOrTypeSpecifier(specifier);
+    this._registry.unregisterOption(normalizedSpecifier, option);
+  }
+
+  registerInjection(specifier: string, property: string, injection: string): void {
+    let normalizedSpecifier = this._toAbsoluteOrTypeSpecifier(specifier);
+    let normalizedInjection = this._toAbsoluteSpecifier(injection);
+    this._registry.registerInjection(normalizedSpecifier, property, normalizedInjection);
+  }
+
+  registeredInjections(specifier: string): Injection[] {
+    let normalizedSpecifier = this._toAbsoluteOrTypeSpecifier(specifier);
+    return this._registry.registeredInjections(normalizedSpecifier);
+  }
+
+  private _toAbsoluteSpecifier(specifier: string, referrer?: string): string {
+    return this._resolver.identify(specifier, referrer);
+  }
+
+  private _toAbsoluteOrTypeSpecifier(specifier: string): string {
+    if (isTypeSpecifier(specifier)) {
+      return specifier;
+    } else {
+      return this._toAbsoluteSpecifier(specifier);
+    }
+  }
+}

--- a/src/application.ts
+++ b/src/application.ts
@@ -143,17 +143,19 @@ export default class Application implements Owner {
    */
 
   identify(specifier: string, referrer?: string): string {
-    return this._toAbsoluteSpecifier(specifier, referrer);
+    if (isSpecifierStringAbsolute(specifier)) {
+      return specifier;
+    } else {
+      return this.resolver.identify(specifier, referrer);
+    }
   }
 
   factoryFor(specifier: string, referrer?: string): Factory<any> {
-    let absoluteSpecifier = this._toAbsoluteSpecifier(specifier, referrer);
-    return this._container.factoryFor(absoluteSpecifier);
+    return this._container.factoryFor(this.identify(specifier, referrer));
   }
 
   lookup(specifier: string, referrer?: string): any {
-    let absoluteSpecifier = this._toAbsoluteSpecifier(specifier, referrer);
-    return this._container.lookup(absoluteSpecifier);
+    return this._container.lookup(this.identify(specifier, referrer));
   }
 
   /**

--- a/src/application.ts
+++ b/src/application.ts
@@ -1,11 +1,10 @@
 import {
   Container,
   Factory,
-  isSpecifierStringAbsolute,
   Owner,
   Registry,
+  RegistryAccessor,
   Resolver,
-  RegistrationOptions,
   setOwner
 } from '@glimmer/di';
 import {
@@ -16,10 +15,7 @@ import {
   Simple,
   templateFactory
 } from '@glimmer/runtime';
-
-function isTypeSpecifier(specifier: string) {
-  return specifier.indexOf(':') === -1;
-}
+import ApplicationRegistry from './application-registry';
 
 export interface ApplicationOptions {
   rootName: string;
@@ -40,8 +36,27 @@ export default class Application implements Owner {
     this.rootName = options.rootName;
     this.rootElement = options.rootElement;
     this.resolver = options.resolver;
+    
+    this.initRegistry();
+  }
 
+  initRegistry(): void {
     this._registry = new Registry();
+
+    // Create ApplicationRegistry as a proxy to the underlying registry
+    // that will only be available during `initialize`.
+    let appRegistry = new ApplicationRegistry(this._registry, this.resolver);
+    this.initialize(appRegistry);
+  }
+
+  initialize(registry: RegistryAccessor): void {
+    registry.register(`environment:/${this.rootName}/main/main`, Environment);
+    registry.registerOption('template', 'instantiate', false);
+
+    // Override and extend to perform custom registrations
+  }
+
+  initContainer(): void {
     this._container = new Container(this._registry, this.resolver);
 
     // Inject `this` (the app) as the "owner" of every object instantiated
@@ -51,16 +66,11 @@ export default class Application implements Owner {
       setOwner(hash, this);
       return hash;
     }
-
-    this.initRegistrations();
-  }
-
-  initRegistrations(): void {
-    this.register(`environment:/${this.rootName}/main/main`, Environment);
-    this.registerOption('template', 'instantiate', false);
   }
 
   boot(): void {
+    this.initContainer();
+
     this.env = this.lookup(`environment:/${this.rootName}/main/main`);
 
     if (!this.rootElement) {
@@ -90,64 +100,11 @@ export default class Application implements Owner {
   }
 
   /**
-   * Registry accessor methods that normalize specifiers.
-   * 
-   * TODO: consider converting Registry to be an interface instead of a class
-   * and then extract these methods to a separate accessor class that implements
-   * Registry.
-   */
-
-  register(specifier: string, factory: any, options?: RegistrationOptions): void {
-    let normalizedSpecifier = this._toAbsoluteSpecifier(specifier);
-    this._registry.register(normalizedSpecifier, factory, options);
-  }
-
-  registration(specifier: string): any {
-    let normalizedSpecifier = this._toAbsoluteSpecifier(specifier);
-    return this._registry.registration(normalizedSpecifier);
-  }
-
-  unregister(specifier: string) {
-    let normalizedSpecifier = this._toAbsoluteSpecifier(specifier);
-    this._registry.unregister(normalizedSpecifier);
-  }
-
-  registerOption(specifier: string, option: string, value: any): void {
-    let normalizedSpecifier = this._toAbsoluteOrTypeSpecifier(specifier);
-    this._registry.registerOption(normalizedSpecifier, option, value);
-  }
-
-  registeredOption(specifier: string, option: string): any {
-    let normalizedSpecifier = this._toAbsoluteOrTypeSpecifier(specifier);
-    return this._registry.registeredOption(normalizedSpecifier, option);
-  }
-
-  registeredOptions(specifier: string): any {
-    let normalizedSpecifier = this._toAbsoluteOrTypeSpecifier(specifier);
-    return this._registry.registeredOptions(normalizedSpecifier);
-  }
-
-  unregisterOption(specifier: string, option: string): void {
-    let normalizedSpecifier = this._toAbsoluteOrTypeSpecifier(specifier);
-    this._registry.unregisterOption(normalizedSpecifier, option);
-  }
-
-  registerInjection(specifier: string, property: string, injection: string): void {
-    let normalizedSpecifier = this._toAbsoluteOrTypeSpecifier(specifier);
-    let normalizedInjection = this._toAbsoluteSpecifier(injection);
-    this._registry.registerInjection(normalizedSpecifier, property, normalizedInjection);
-  }
-
-  /**
    * Owner interface implementation
    */
 
   identify(specifier: string, referrer?: string): string {
-    if (isSpecifierStringAbsolute(specifier)) {
-      return specifier;
-    } else {
-      return this.resolver.identify(specifier, referrer);
-    }
+    return this.resolver.identify(specifier, referrer);
   }
 
   factoryFor(specifier: string, referrer?: string): Factory<any> {
@@ -156,25 +113,5 @@ export default class Application implements Owner {
 
   lookup(specifier: string, referrer?: string): any {
     return this._container.lookup(this.identify(specifier, referrer));
-  }
-
-  /**
-   * Private methods
-   */
-
-  private _toAbsoluteSpecifier(specifier: string, referrer?: string): string {
-    if (isSpecifierStringAbsolute(specifier)) {
-      return specifier;
-    } else {
-      return this.resolver.identify(specifier, referrer);
-    }
-  }
-
-  private _toAbsoluteOrTypeSpecifier(specifier: string): string {
-    if (isTypeSpecifier(specifier)) {
-      return specifier;
-    } else {
-      return this._toAbsoluteSpecifier(specifier);
-    }
   }
 }

--- a/src/application.ts
+++ b/src/application.ts
@@ -24,7 +24,7 @@ function isTypeSpecifier(specifier: string) {
 export interface ApplicationOptions {
   rootName: string;
   rootElement?: Simple.Element;
-  resolver?: Resolver;
+  resolver: Resolver;
 }
 
 export default class Application implements Owner {

--- a/test/application-as-owner-test.ts
+++ b/test/application-as-owner-test.ts
@@ -1,27 +1,25 @@
 import Application from '../src/application';
-import { Resolver, getOwner } from '@glimmer/di';
+import { Resolver, getOwner, isSpecifierStringAbsolute } from '@glimmer/di';
 import { BlankResolver } from './test-helpers/resolvers';
 
 const { module, test } = QUnit;
 
 module('Application - Owner interface');
 
-test('#identify - returns an absolute specifier unchanged', function(assert) {
-  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
-  let absSpecifier = 'component:/app/components/date-picker';
-  assert.equal(app.identify(absSpecifier), absSpecifier, 'specifier was returned unchanged');
-});
-
 test('#identify - uses a resolver to convert a relative specifier to an absolute specifier', function(assert) {
   assert.expect(2);
 
   class FakeResolver implements Resolver {
     identify(specifier: string, referrer?: string) {
+      if (isSpecifierStringAbsolute(specifier)) {
+        return specifier;
+      }
       assert.equal(specifier, 'component:date-picker', 'FakeResolver#identify was invoked');
       return 'component:/app/components/date-picker';
     }
     retrieve(specifier: string): any {}
   }
+
   let resolver = new FakeResolver();
   let app = new Application({ rootName: 'app', resolver });
   let specifier = 'component:date-picker';
@@ -33,9 +31,14 @@ test('#factoryFor - returns a registered factory', function(assert) {
     static create() { return { foo: 'bar' }; }
   }
 
-  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
-
-  app.register('component:/app/components/date-picker', DatePicker);
+  class App extends Application {
+    initialize(registry) {
+      super.initialize(registry);
+      registry.register('component:/app/components/date-picker', DatePicker);
+    }
+  }
+  let app = new App({ rootName: 'app', resolver: new BlankResolver });
+  app.initContainer();
   assert.strictEqual(app.factoryFor('component:/app/components/date-picker'), DatePicker, 'expected factory was returned');
 });
 
@@ -48,6 +51,9 @@ test('#factoryFor - will use a resolver to locate a factory', function(assert) {
 
   class FakeResolver implements Resolver {
     identify(specifier: string, referrer?: string) {
+      if (isSpecifierStringAbsolute(specifier)) {
+        return specifier;
+      }
       assert.equal(specifier, 'component:date-picker', 'FakeResolver#identify was invoked');
       return 'component:/app/components/date-picker';
     }
@@ -59,6 +65,7 @@ test('#factoryFor - will use a resolver to locate a factory', function(assert) {
 
   let resolver = new FakeResolver();
   let app = new Application({ rootName: 'app', resolver });
+  app.initContainer();
   assert.strictEqual(app.factoryFor('component:date-picker'), DatePicker, 'expected factory was returned');
 });
 
@@ -74,8 +81,11 @@ test('#factoryFor - will use a resolver to locate a factory, even if one is regi
   }
 
   class FakeResolver implements Resolver {
-    identify(fullName: string, referrer: string) {
-      assert.equal(fullName, 'foo:bar', 'FakeResolver#identify was invoked');
+    identify(specifier: string, referrer: string) {
+      if (isSpecifierStringAbsolute(specifier)) {
+        return specifier;
+      }
+      assert.equal(specifier, 'foo:bar', 'FakeResolver#identify was invoked');
       return 'foo:/app/foos/bar';
     }
     retrieve(id: string): any {
@@ -85,8 +95,16 @@ test('#factoryFor - will use a resolver to locate a factory, even if one is regi
   }
 
   let resolver = new FakeResolver();
-  let app = new Application({ rootName: 'app', resolver });
-  app.register('foo:/app/foos/bar', Foo);
+
+  class App extends Application {
+    initialize(registry) {
+      super.initialize(registry);
+      registry.register('foo:/app/foos/bar', Foo);
+    }
+  }
+
+  let app = new App({ rootName: 'app', resolver });
+  app.initContainer();
   assert.strictEqual(app.factoryFor('foo:bar'), FooBar, 'factory from resolver was returned');
 });
 
@@ -103,9 +121,15 @@ test('#lookup - returns an instance created by the factory', function(assert) {
     }
   }
 
-  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
+  class App extends Application {
+    initialize(registry) {
+      super.initialize(registry);
+      registry.register('foo:/app/foos/bar', FooBar);
+    }
+  }
 
-  app.register('foo:/app/foos/bar', FooBar);
+  let app = new App({ rootName: 'app', resolver: new BlankResolver() });
+  app.initContainer();
   let foobar = app.lookup('foo:/app/foos/bar');
   assert.strictEqual(foobar, instance, 'instance created');
 });
@@ -122,9 +146,16 @@ test('#lookup - caches looked up instances by default', function(assert) {
     }
   }
 
-  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
+  class App extends Application {
+    initialize(registry) {
+      super.initialize(registry);
+      registry.register('foo:/app/foos/bar', FooBar);
+    }
+  }
 
-  app.register('foo:/app/foos/bar', FooBar);
+  let app = new App({ rootName: 'app', resolver: new BlankResolver() });
+  app.initContainer();
+
   let foo1 = app.lookup('foo:/app/foos/bar');
   assert.equal(createCounter, 1);
   let foo2 = app.lookup('foo:/app/foos/bar');
@@ -144,9 +175,16 @@ test('#lookup - will not cache lookups specified as non-singletons', function(as
     }
   }
 
-  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
+  class App extends Application {
+    initialize(registry) {
+      super.initialize(registry);
+      registry.register('foo:/app/foos/bar', FooBar, { singleton: false });
+    }
+  }
 
-  app.register('foo:/app/foos/bar', FooBar, { singleton: false });
+  let app = new App({ rootName: 'app', resolver: new BlankResolver() });
+  app.initContainer();
+
   let foo1 = app.lookup('foo:/app/foos/bar');
   assert.equal(createCounter, 1);
   let foo2 = app.lookup('foo:/app/foos/bar');
@@ -161,9 +199,16 @@ test('#lookup - returns the factory when registrations specify instantiate: fals
 
   let factory = {};
 
-  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
+  class App extends Application {
+    initialize(registry) {
+      super.initialize(registry);
+      registry.register('foo:/app/foos/bar', factory, { instantiate: false });
+    }
+  }
 
-  app.register('foo:/app/foos/bar', factory, { instantiate: false });
+  let app = new App({ rootName: 'app', resolver: new BlankResolver() });
+  app.initContainer();
+
   let foo1 = app.lookup('foo:/app/foos/bar');
   assert.strictEqual(foo1, factory);
 });
@@ -177,6 +222,9 @@ test('#lookup - uses the resolver to locate a registration', function(assert) {
 
   class FakeResolver implements Resolver {
     identify(specifier: string, referrer?: string): string {
+      if (isSpecifierStringAbsolute(specifier)) {
+        return specifier;
+      }
       assert.equal(specifier, 'foo:bar', 'FakeResolver#identify was invoked');
       return 'foo:/app/foos/bar';
     }
@@ -188,6 +236,7 @@ test('#lookup - uses the resolver to locate a registration', function(assert) {
 
   let resolver = new FakeResolver();
   let app = new Application({ rootName: 'app', resolver });
+  app.initContainer();
   let foo1 = app.lookup('foo:bar');
 
   assert.deepEqual(foo1, { foo: 'bar' }, 'expected factory was invoked');
@@ -215,10 +264,18 @@ test('#lookup - injects references registered by name', function(assert) {
     }
   }
 
-  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
-  app.register('foo:/app/foos/bar', FooBar);
-  app.register('router:/app/root/main', Router);
-  app.registerInjection('foo:/app/foos/bar', 'router', 'router:/app/root/main');
+  class App extends Application {
+    initialize(registry) {
+      super.initialize(registry);
+      registry.register('foo:/app/foos/bar', FooBar);
+      registry.register('router:/app/root/main', Router);
+      registry.registerInjection('foo:/app/foos/bar', 'router', 'router:/app/root/main');
+    }
+  }
+
+  let app = new App({ rootName: 'app', resolver: new BlankResolver() });
+  app.initContainer();
+
   assert.strictEqual(app.lookup('foo:/app/foos/bar'), instance, 'instance returned');
   assert.strictEqual(instance['router'], router, 'injection has been applied to instance');
 });
@@ -245,10 +302,18 @@ test('#lookup - injects references registered by type', function(assert) {
     }
   }
 
-  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
-  app.register('foo:/app/foos/bar', FooBar);
-  app.register('router:/app/root/main', Router);
-  app.registerInjection('foo:/app/foos/bar', 'router', 'router:/app/root/main');
+  class App extends Application {
+    initialize(registry) {
+      super.initialize(registry);
+      registry.register('foo:/app/foos/bar', FooBar);
+      registry.register('router:/app/root/main', Router);
+      registry.registerInjection('foo:/app/foos/bar', 'router', 'router:/app/root/main');
+    }
+  }
+
+  let app = new App({ rootName: 'app', resolver: new BlankResolver() });
+  app.initContainer();
+
   assert.strictEqual(app.lookup('foo:/app/foos/bar'), instance, 'instance returned');
   assert.strictEqual(instance['router'], router, 'injection has been applied to instance');
 });

--- a/test/application-as-owner-test.ts
+++ b/test/application-as-owner-test.ts
@@ -1,12 +1,13 @@
 import Application from '../src/application';
 import { Resolver, getOwner } from '@glimmer/di';
+import { BlankResolver } from './test-helpers/resolvers';
 
 const { module, test } = QUnit;
 
-module('Application - Container interface');
+module('Application - Owner interface');
 
 test('#identify - returns an absolute specifier unchanged', function(assert) {
-  let app = new Application({ rootName: 'app' });
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
   let absSpecifier = 'component:/app/components/date-picker';
   assert.equal(app.identify(absSpecifier), absSpecifier, 'specifier was returned unchanged');
 });
@@ -32,7 +33,7 @@ test('#factoryFor - returns a registered factory', function(assert) {
     static create() { return { foo: 'bar' }; }
   }
 
-  let app = new Application({ rootName: 'app' });
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
 
   app.register('component:/app/components/date-picker', DatePicker);
   assert.strictEqual(app.factoryFor('component:/app/components/date-picker'), DatePicker, 'expected factory was returned');
@@ -102,7 +103,7 @@ test('#lookup - returns an instance created by the factory', function(assert) {
     }
   }
 
-  let app = new Application({ rootName: 'app' });
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
 
   app.register('foo:/app/foos/bar', FooBar);
   let foobar = app.lookup('foo:/app/foos/bar');
@@ -121,7 +122,7 @@ test('#lookup - caches looked up instances by default', function(assert) {
     }
   }
 
-  let app = new Application({ rootName: 'app' });
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
 
   app.register('foo:/app/foos/bar', FooBar);
   let foo1 = app.lookup('foo:/app/foos/bar');
@@ -143,7 +144,7 @@ test('#lookup - will not cache lookups specified as non-singletons', function(as
     }
   }
 
-  let app = new Application({ rootName: 'app' });
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
 
   app.register('foo:/app/foos/bar', FooBar, { singleton: false });
   let foo1 = app.lookup('foo:/app/foos/bar');
@@ -160,7 +161,7 @@ test('#lookup - returns the factory when registrations specify instantiate: fals
 
   let factory = {};
 
-  let app = new Application({ rootName: 'app' });
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
 
   app.register('foo:/app/foos/bar', factory, { instantiate: false });
   let foo1 = app.lookup('foo:/app/foos/bar');
@@ -214,7 +215,7 @@ test('#lookup - injects references registered by name', function(assert) {
     }
   }
 
-  let app = new Application({ rootName: 'app' });
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
   app.register('foo:/app/foos/bar', FooBar);
   app.register('router:/app/root/main', Router);
   app.registerInjection('foo:/app/foos/bar', 'router', 'router:/app/root/main');
@@ -244,7 +245,7 @@ test('#lookup - injects references registered by type', function(assert) {
     }
   }
 
-  let app = new Application({ rootName: 'app' });
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
   app.register('foo:/app/foos/bar', FooBar);
   app.register('router:/app/root/main', Router);
   app.registerInjection('foo:/app/foos/bar', 'router', 'router:/app/root/main');

--- a/test/application-registry-test.ts
+++ b/test/application-registry-test.ts
@@ -1,21 +1,22 @@
-import Application from '../src/application';
-import { Resolver, getOwner } from '@glimmer/di';
+import ApplicationRegistry from '../src/application-registry';
+import { Registry, Resolver, getOwner } from '@glimmer/di';
 import { BlankResolver } from './test-helpers/resolvers';
 
 const { module, test } = QUnit;
 
-module('Application - Registry interface');
+module('ApplicationRegistry');
 
 test('#register - registers a factory', function(assert) {
   class Foo {
     static create() { return { foo: 'bar' }; }
   }
 
-  let app = new Application({ rootName: 'app', resolver: new BlankResolver });
+  let registry = new Registry();
+  let appRegistry = new ApplicationRegistry(registry, new BlankResolver);
 
-  assert.strictEqual(app.registration('foo:/app/foos/bar'), undefined, 'factory has not yet been registered');
-  app.register('foo:/app/foos/bar', Foo);
-  assert.strictEqual(app.registration('foo:/app/foos/bar'), Foo, 'factory has been registered');
+  assert.strictEqual(appRegistry.registration('foo:/app/foos/bar'), undefined, 'factory has not yet been registered');
+  appRegistry.register('foo:/app/foos/bar', Foo);
+  assert.strictEqual(appRegistry.registration('foo:/app/foos/bar'), Foo, 'factory has been registered');
 });
 
 test('#register - can register options together with a factory', function(assert) {
@@ -23,12 +24,13 @@ test('#register - can register options together with a factory', function(assert
     static create() { return { foo: 'bar' }; }
   }
 
-  let app = new Application({ rootName: 'app', resolver: new BlankResolver });
+  let registry = new Registry();
+  let appRegistry = new ApplicationRegistry(registry, new BlankResolver);
 
-  assert.strictEqual(app.registration('foo:/app/foos/bar'), undefined, 'factory has not yet been registered');
-  app.register('foo:/app/foos/bar', Foo, { instantiate: false });
-  assert.strictEqual(app.registration('foo:/app/foos/bar'), Foo, 'factory has been registered');
-  assert.deepEqual(app.registeredOptions('foo:/app/foos/bar'), { instantiate: false }, 'options have been registered');
+  assert.strictEqual(appRegistry.registration('foo:/app/foos/bar'), undefined, 'factory has not yet been registered');
+  appRegistry.register('foo:/app/foos/bar', Foo, { instantiate: false });
+  assert.strictEqual(appRegistry.registration('foo:/app/foos/bar'), Foo, 'factory has been registered');
+  assert.deepEqual(appRegistry.registeredOptions('foo:/app/foos/bar'), { instantiate: false }, 'options have been registered');
 });
 
 test('#registration - returns a factory has been registered', function(assert) {
@@ -36,11 +38,12 @@ test('#registration - returns a factory has been registered', function(assert) {
     static create() { return { foo: 'bar' }; }
   }
 
-  let app = new Application({ rootName: 'app', resolver: new BlankResolver });
+  let registry = new Registry();
+  let appRegistry = new ApplicationRegistry(registry, new BlankResolver);
 
-  assert.strictEqual(app.registration('foo:/app/foos/bar'), undefined, 'factory has not yet been registered');
-  app.register('foo:/app/foos/bar', Foo);
-  assert.strictEqual(app.registration('foo:/app/foos/bar'), Foo, 'factory has been registered');
+  assert.strictEqual(appRegistry.registration('foo:/app/foos/bar'), undefined, 'factory has not yet been registered');
+  appRegistry.register('foo:/app/foos/bar', Foo);
+  assert.strictEqual(appRegistry.registration('foo:/app/foos/bar'), Foo, 'factory has been registered');
 });
 
 test('#unregister - unregisters a factory', function(assert) {
@@ -48,12 +51,13 @@ test('#unregister - unregisters a factory', function(assert) {
     static create() { return { foo: 'bar' }; }
   }
 
-  let app = new Application({ rootName: 'app', resolver: new BlankResolver });
+  let registry = new Registry();
+  let appRegistry = new ApplicationRegistry(registry, new BlankResolver);
 
-  app.register('foo:/app/foos/bar', Foo);
-  assert.strictEqual(app.registration('foo:/app/foos/bar'), Foo, 'factory has been registered');
-  app.unregister('foo:/app/foos/bar');
-  assert.strictEqual(app.registration('foo:/app/foos/bar'), undefined, 'factory been unregistered');
+  appRegistry.register('foo:/app/foos/bar', Foo);
+  assert.strictEqual(appRegistry.registration('foo:/app/foos/bar'), Foo, 'factory has been registered');
+  appRegistry.unregister('foo:/app/foos/bar');
+  assert.strictEqual(appRegistry.registration('foo:/app/foos/bar'), undefined, 'factory been unregistered');
 });
 
 test('#registerOption, #registeredOptions, #registeredOption, #unregisterOption', function(assert) {
@@ -61,19 +65,20 @@ test('#registerOption, #registeredOptions, #registeredOption, #unregisterOption'
     static create() { return { foo: 'bar' }; }
   }
 
-  let app = new Application({ rootName: 'app', resolver: new BlankResolver });
+  let registry = new Registry();
+  let appRegistry = new ApplicationRegistry(registry, new BlankResolver);
 
-  app.register('foo:/app/foos/bar', Foo);
-  assert.strictEqual(app.registeredOptions('foo:/app/foos/bar'), undefined);
-  assert.strictEqual(app.registeredOption('foo:/app/foos/bar', 'singleton'), undefined);
+  appRegistry.register('foo:/app/foos/bar', Foo);
+  assert.strictEqual(appRegistry.registeredOptions('foo:/app/foos/bar'), undefined);
+  assert.strictEqual(appRegistry.registeredOption('foo:/app/foos/bar', 'singleton'), undefined);
 
-  app.registerOption('foo:/app/foos/bar', 'singleton', true);
-  assert.deepEqual(app.registeredOptions('foo:/app/foos/bar'), {singleton: true});
-  assert.strictEqual(app.registeredOption('foo:/app/foos/bar', 'singleton'), true);
+  appRegistry.registerOption('foo:/app/foos/bar', 'singleton', true);
+  assert.deepEqual(appRegistry.registeredOptions('foo:/app/foos/bar'), {singleton: true});
+  assert.strictEqual(appRegistry.registeredOption('foo:/app/foos/bar', 'singleton'), true);
 
-  app.unregisterOption('foo:/app/foos/bar', 'singleton');
-  assert.deepEqual(app.registeredOptions('foo:/app/foos/bar'), {});
-  assert.strictEqual(app.registeredOption('foo:/app/foos/bar', 'singleton'), undefined);
+  appRegistry.unregisterOption('foo:/app/foos/bar', 'singleton');
+  assert.deepEqual(appRegistry.registeredOptions('foo:/app/foos/bar'), {});
+  assert.strictEqual(appRegistry.registeredOption('foo:/app/foos/bar', 'singleton'), undefined);
 });
 
 test('Options registered by full name supercede those registered by type', function(assert) {
@@ -81,12 +86,13 @@ test('Options registered by full name supercede those registered by type', funct
     static create() { return { foo: 'bar' }; }
   }
 
-  let app = new Application({ rootName: 'app', resolver: new BlankResolver });
+  let registry = new Registry();
+  let appRegistry = new ApplicationRegistry(registry, new BlankResolver);
 
-  app.register('foo:/app/foos/bar', Foo);
+  appRegistry.register('foo:/app/foos/bar', Foo);
 
-  app.registerOption('foo', 'singleton', false);
-  assert.strictEqual(app.registeredOption('foo:/app/foos/bar', 'singleton'), false);
-  app.registerOption('foo:/app/foos/bar', 'singleton', true);
-  assert.strictEqual(app.registeredOption('foo:/app/foos/bar', 'singleton'), true);
+  appRegistry.registerOption('foo', 'singleton', false);
+  assert.strictEqual(appRegistry.registeredOption('foo:/app/foos/bar', 'singleton'), false);
+  appRegistry.registerOption('foo:/app/foos/bar', 'singleton', true);
+  assert.strictEqual(appRegistry.registeredOption('foo:/app/foos/bar', 'singleton'), true);
 });

--- a/test/application-registry-test.ts
+++ b/test/application-registry-test.ts
@@ -1,5 +1,6 @@
 import Application from '../src/application';
 import { Resolver, getOwner } from '@glimmer/di';
+import { BlankResolver } from './test-helpers/resolvers';
 
 const { module, test } = QUnit;
 
@@ -10,7 +11,7 @@ test('#register - registers a factory', function(assert) {
     static create() { return { foo: 'bar' }; }
   }
 
-  let app = new Application({ rootName: 'app' });
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver });
 
   assert.strictEqual(app.registration('foo:/app/foos/bar'), undefined, 'factory has not yet been registered');
   app.register('foo:/app/foos/bar', Foo);
@@ -22,7 +23,7 @@ test('#register - can register options together with a factory', function(assert
     static create() { return { foo: 'bar' }; }
   }
 
-  let app = new Application({ rootName: 'app' });
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver });
 
   assert.strictEqual(app.registration('foo:/app/foos/bar'), undefined, 'factory has not yet been registered');
   app.register('foo:/app/foos/bar', Foo, { instantiate: false });
@@ -35,7 +36,7 @@ test('#registration - returns a factory has been registered', function(assert) {
     static create() { return { foo: 'bar' }; }
   }
 
-  let app = new Application({ rootName: 'app' });
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver });
 
   assert.strictEqual(app.registration('foo:/app/foos/bar'), undefined, 'factory has not yet been registered');
   app.register('foo:/app/foos/bar', Foo);
@@ -47,7 +48,7 @@ test('#unregister - unregisters a factory', function(assert) {
     static create() { return { foo: 'bar' }; }
   }
 
-  let app = new Application({ rootName: 'app' });
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver });
 
   app.register('foo:/app/foos/bar', Foo);
   assert.strictEqual(app.registration('foo:/app/foos/bar'), Foo, 'factory has been registered');
@@ -60,7 +61,7 @@ test('#registerOption, #registeredOptions, #registeredOption, #unregisterOption'
     static create() { return { foo: 'bar' }; }
   }
 
-  let app = new Application({ rootName: 'app' });
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver });
 
   app.register('foo:/app/foos/bar', Foo);
   assert.strictEqual(app.registeredOptions('foo:/app/foos/bar'), undefined);
@@ -80,7 +81,7 @@ test('Options registered by full name supercede those registered by type', funct
     static create() { return { foo: 'bar' }; }
   }
 
-  let app = new Application({ rootName: 'app' });
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver });
 
   app.register('foo:/app/foos/bar', Foo);
 

--- a/test/application-test.ts
+++ b/test/application-test.ts
@@ -1,10 +1,11 @@
 import Application from '../src/application';
+import { BlankResolver } from './test-helpers/resolvers';
 
 const { module, test } = QUnit;
 
 module('Application');
 
 test('can be instantiated', function(assert) {
-  let app = new Application({ rootName: 'app' });
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver });
   assert.ok(app, 'app exists');
 });

--- a/test/test-helpers/resolvers.ts
+++ b/test/test-helpers/resolvers.ts
@@ -1,8 +1,10 @@
-import { Resolver } from '@glimmer/di';
+import { Resolver, isSpecifierStringAbsolute } from '@glimmer/di';
 
 export class BlankResolver implements Resolver {
   identify(specifier: string, referrer?: string) { 
-    return '';
+    if (isSpecifierStringAbsolute(specifier)) {
+      return specifier;
+    }
   }
   retrieve(specifier: string): any {
   }

--- a/test/test-helpers/resolvers.ts
+++ b/test/test-helpers/resolvers.ts
@@ -1,0 +1,9 @@
+import { Resolver } from '@glimmer/di';
+
+export class BlankResolver implements Resolver {
+  identify(specifier: string, referrer?: string) { 
+    return '';
+  }
+  retrieve(specifier: string): any {
+  }
+}


### PR DESCRIPTION
Applications now require a `resolver` to be constructed, since they need the `identify` method to normalize specifiers.

Registry access has been extracted into a new `ApplicationRegistry` class, an instance of which is passed to the new `initialize` method before the app has been booted.
