### PR TITLE
Move Environment and supporting modules from glimmer-component

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "testem ci"
   },
   "dependencies": {
-    "@glimmer/component": "^0.1.0",
+    "@glimmer/component": "^0.2.0",
     "@glimmer/di": "^0.1.8",
     "@glimmer/util": "^0.21.0"
   },

--- a/src/application.ts
+++ b/src/application.ts
@@ -8,14 +8,12 @@ import {
   setOwner
 } from '@glimmer/di';
 import {
-  DynamicScope,
-  Environment
-} from '@glimmer/component';
-import {
   Simple,
   templateFactory
 } from '@glimmer/runtime';
 import ApplicationRegistry from './application-registry';
+import DynamicScope from './dynamic-scope';
+import Environment from './environment';
 
 export interface ApplicationOptions {
   rootName: string;

--- a/src/dynamic-scope.ts
+++ b/src/dynamic-scope.ts
@@ -1,0 +1,34 @@
+import {
+  assign,
+  Opaque
+} from '@glimmer/util';
+import {
+  DynamicScope as GlimmerDynamicScope
+} from '@glimmer/runtime';
+import {
+  PathReference
+} from '@glimmer/reference';
+
+export default class DynamicScope implements GlimmerDynamicScope {
+  private bucket;
+
+  constructor(bucket=null) {
+    if (bucket) {
+      this.bucket = assign({}, bucket);
+    } else {
+      this.bucket = {};
+    }
+  }
+
+  get(key: string): PathReference<Opaque> {
+    return this.bucket[key];
+  }
+
+  set(key: string, reference: PathReference<Opaque>) {
+    return this.bucket[key] = reference;
+  }
+
+  child(): DynamicScope {
+    return new DynamicScope(this.bucket);
+  }
+}

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,0 +1,199 @@
+import {
+  CompiledBlock,
+  ComponentClass,
+  DOMChanges,
+  DOMTreeConstruction,
+  Environment as GlimmerEnvironment,
+  EvaluatedArgs,
+  Helper as GlimmerHelper,
+  ModifierManager,
+  PartialDefinition,
+  Simple,
+  compileLayout
+} from '@glimmer/runtime';
+import {
+  Reference,
+  RevisionTag,
+  PathReference,
+  OpaqueIterator,
+  OpaqueIterable,
+  AbstractIterable,
+  IterationItem,
+  VOLATILE_TAG
+} from "@glimmer/reference";
+import {
+  Dict,
+  dict,
+  assign,
+  initializeGuid,
+  Opaque,
+  FIXME
+} from '@glimmer/util';
+import {
+  TemplateMeta
+} from "@glimmer/wire-format";
+import {
+  SymbolTable
+} from '@glimmer/interfaces';
+import {
+  getOwner,
+  setOwner,
+  Owner
+} from '@glimmer/di';
+import Component, {
+  ComponentFactory,
+  ComponentDefinition,
+  ComponentLayoutCompiler,
+  ComponentManager
+} from '@glimmer/component';
+import Iterable from './iterable';
+
+type KeyFor<T> = (item: Opaque, index: T) => string;
+
+export interface EnvironmentOptions {
+  document?: Simple.Document;
+  appendOperations?: DOMTreeConstruction;
+}
+
+export default class Environment extends GlimmerEnvironment {
+  private helpers = dict<GlimmerHelper>();
+  private modifiers = dict<ModifierManager<Opaque>>();
+  private partials = dict<PartialDefinition<{}>>();
+  private components = dict<ComponentDefinition>();
+  private uselessAnchor: Simple.HTMLAnchorElement;
+  private componentManager: ComponentManager;
+  public compiledLayouts = dict<any>();
+
+  static create(options: EnvironmentOptions = {}) {
+    options.document = options.document || self.document;
+    options.appendOperations = options.appendOperations || new DOMTreeConstruction(options.document);
+
+    return new Environment(options);
+  }
+
+  constructor(options: EnvironmentOptions) {
+    super({ appendOperations: options.appendOperations, updateOperations: new DOMChanges(options.document as Simple.Document) });
+
+    setOwner(this, getOwner(options));
+
+    // TODO - allow more than one component manager per environment
+    this.componentManager = new ComponentManager(this);
+
+    // TODO - required for `protocolForURL` - seek alternative approach
+    // e.g. see `installPlatformSpecificProtocolForURL` in Ember
+    this.uselessAnchor = options.document.createElement('a') as Simple.HTMLAnchorElement;
+  }
+
+  begin() {
+    super.begin();
+  }
+
+  commit() {
+    super.commit();
+  }
+
+  protocolForURL(url: string): string {
+    // TODO - investigate alternative approaches
+    // e.g. see `installPlatformSpecificProtocolForURL` in Ember
+    this.uselessAnchor.href = url;
+    return this.uselessAnchor.protocol;
+  }
+
+  registerComponent(specifier: string): ComponentDefinition {
+    let owner: Owner = getOwner(this);
+    let ComponentClass = owner.factoryFor(specifier);
+    let componentDef: ComponentDefinition = new ComponentDefinition(specifier, this.componentManager, ComponentClass);
+    this.components[specifier] = componentDef;
+
+    // TODO - allow templates to be defined on the component class itself?
+    let componentTemplate = owner.lookup('template', specifier);
+    let componentLayout = this.getCompiledBlock(ComponentLayoutCompiler, componentTemplate);
+    this.compiledLayouts[specifier] = componentLayout;
+
+    return componentDef;
+  }
+
+  hasPartial(partialName: string) {
+    return partialName in this.partials;
+  }
+
+  lookupPartial(partialName: string) {
+    let partial = this.partials[partialName];
+
+    return partial;
+  }
+
+  hasComponentDefinition(name: string[], symbolTable: SymbolTable): boolean {
+    return !!this.getComponentDefinition(name, symbolTable);
+  }
+
+  getComponentDefinition(name: string[], symbolTable: SymbolTable): ComponentDefinition {
+    let owner: Owner = getOwner(this);
+    let relSpecifier: string = `component:${name.join('/')}`;
+    let referrer: string = symbolTable.meta.specifier;
+    let specifier = owner.identify(relSpecifier, referrer);
+
+    if (!this.components[specifier]) {
+      this.registerComponent(specifier);
+    }
+
+    return this.components[specifier];
+  }
+
+  hasHelper(helperName: string[], blockMeta: TemplateMeta) {
+    return helperName.length === 1 && (<string>helperName[0] in this.helpers);
+  }
+
+  lookupHelper(helperName: string[], blockMeta: TemplateMeta) {
+    let name = helperName[0];
+
+    let helper = this.helpers[name];
+
+    if (!helper) throw new Error(`Helper for ${helperName.join('.')} not found.`);
+
+    return helper;
+  }
+
+  hasModifier(modifierName: string[], blockMeta: TemplateMeta): boolean {
+    return modifierName.length === 1 && (<string>modifierName[0] in this.modifiers);
+  }
+
+  lookupModifier(modifierName: string[], blockMeta: TemplateMeta): ModifierManager<Opaque> {
+    let [name] = modifierName;
+
+    let modifier = this.modifiers[name];
+
+    if(!modifier) throw new Error(`Modifier for ${modifierName.join('.')} not found.`);
+    return modifier;
+  }
+
+  iterableFor(ref: Reference<Opaque>, args: EvaluatedArgs): OpaqueIterable {
+    let keyPath = args.named.get("key").value() as FIXME<any, "User value to lookup key">;
+    let keyFor: KeyFor<Opaque>;
+
+    if (!keyPath) {
+      throw new Error('Must specify a key for #each');
+    }
+
+    switch (keyPath) {
+      case '@index':
+        keyFor = (_, index: number) => String(index);
+      break;
+      case '@primitive':
+        keyFor = (item: Opaque) => String(item);
+      break;
+      default:
+        keyFor = (item: Opaque) => item[keyPath];
+      break;
+    }
+
+    return new Iterable(ref, keyFor);
+  }
+
+  // a Compiler can wrap the template so it needs its own cache
+  getCompiledBlock(Compiler: any, template: string): CompiledBlock {
+    // TODO - add caching (see environment.js in Ember)
+    let compilable = new Compiler(template);
+    return compileLayout(compilable, this);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { default as Application, ApplicationOptions } from './application';
+export { default, ApplicationOptions } from './application';
 export { default as Environment } from './environment';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { default as Application, ApplicationOptions } from './application';
+export { default as Environment } from './environment';

--- a/src/iterable.ts
+++ b/src/iterable.ts
@@ -1,0 +1,140 @@
+import {
+  Opaque
+} from '@glimmer/util';
+
+import {
+  RevisionTag,
+  Reference,
+  OpaqueIterator,
+  AbstractIterable,
+  IterationItem
+} from "@glimmer/reference";
+
+import {
+  UpdatableReference
+} from "@glimmer/object-reference";
+
+export type KeyFor<T> = (item: Opaque, index: T) => string;
+
+class ArrayIterator implements OpaqueIterator {
+  private array: Opaque[];
+  private keyFor: KeyFor<number>;
+  private position = 0;
+
+  constructor(array: Opaque[], keyFor: KeyFor<number>) {
+    this.array = array;
+    this.keyFor = keyFor;
+  }
+
+  isEmpty(): boolean {
+    return this.array.length === 0;
+  }
+
+  next(): IterationItem<Opaque, number> {
+    let { position, array, keyFor } = this;
+
+    if (position >= array.length) return null;
+
+    let value = array[position];
+    let key = keyFor(value, position);
+    let memo = position;
+
+    this.position++;
+
+    return { key, value, memo };
+  }
+}
+
+class ObjectKeysIterator implements OpaqueIterator {
+  private keys: string[];
+  private values: Opaque[];
+  private keyFor: KeyFor<string>;
+  private position = 0;
+
+  constructor(keys: string[], values: Opaque[], keyFor: KeyFor<string>) {
+    this.keys = keys;
+    this.values = values;
+    this.keyFor = keyFor;
+  }
+
+  isEmpty(): boolean {
+    return this.keys.length === 0;
+  }
+
+  next(): IterationItem<Opaque, string> {
+    let { position, keys, values, keyFor } = this;
+
+    if (position >= keys.length) return null;
+
+    let value = values[position];
+    let memo = keys[position];
+    let key = keyFor(value, memo);
+
+    this.position++;
+
+    return { key, value, memo };
+  }
+}
+
+class EmptyIterator implements OpaqueIterator {
+  isEmpty(): boolean {
+    return true;
+  }
+
+  next(): IterationItem<Opaque, Opaque> {
+    throw new Error(`Cannot call next() on an empty iterator`);
+  }
+}
+
+const EMPTY_ITERATOR = new EmptyIterator();
+
+export default class Iterable implements AbstractIterable<Opaque, Opaque, IterationItem<Opaque, Opaque>, UpdatableReference<Opaque>, UpdatableReference<Opaque>> {
+  public tag: RevisionTag;
+  private ref: Reference<Opaque>;
+  private keyFor: KeyFor<Opaque>;
+
+  constructor(ref: Reference<Opaque>, keyFor: KeyFor<Opaque>) {
+    this.tag = ref.tag;
+    this.ref = ref;
+    this.keyFor = keyFor;
+  }
+
+  iterate(): OpaqueIterator {
+    let { ref, keyFor } = this;
+
+    let iterable = ref.value() as any;
+
+    if (Array.isArray(iterable)) {
+      return iterable.length > 0 ? new ArrayIterator(iterable, keyFor) : EMPTY_ITERATOR;
+    } else if (iterable === undefined || iterable === null) {
+      return EMPTY_ITERATOR;
+    } else if (iterable.forEach !== undefined) {
+      let array = [];
+      iterable.forEach(function(item) {
+        array.push(item);
+      });
+      return array.length > 0 ? new ArrayIterator(array, keyFor) : EMPTY_ITERATOR;
+    } else if (typeof iterable === 'object') {
+       let keys = Object.keys(iterable);
+       return keys.length > 0 ? new ObjectKeysIterator(keys, keys.map(key => iterable[key]), keyFor) : EMPTY_ITERATOR;
+     } else {
+      throw new Error(`Don't know how to {{#each ${iterable}}}`);
+    }
+  }
+
+  valueReferenceFor(item: IterationItem<Opaque, Opaque>): UpdatableReference<Opaque> {
+    return new UpdatableReference(item.value);
+  }
+
+  updateValueReference(reference: UpdatableReference<Opaque>, item: IterationItem<Opaque, Opaque>) {
+    reference.update(item.value);
+  }
+
+  memoReferenceFor(item: IterationItem<Opaque, Opaque>): UpdatableReference<Opaque> {
+    return new UpdatableReference(item.memo);
+  }
+
+  updateMemoReference(reference: UpdatableReference<Opaque>, item: IterationItem<Opaque, Opaque>) {
+    reference.update(item.memo);
+  }
+}

--- a/test/environment-test.ts
+++ b/test/environment-test.ts
@@ -1,0 +1,98 @@
+import { getOwner, setOwner, Owner, OWNER, Factory } from '@glimmer/di';
+import { UpdatableReference } from '@glimmer/object-reference';
+import { DOMTreeConstruction, templateFactory } from '@glimmer/runtime';
+import Environment, { EnvironmentOptions } from '../src/environment';
+import Component, {
+  ComponentManager
+} from '@glimmer/component';
+import DynamicScope from '../src/dynamic-scope';
+import { precompile } from './test-helpers/compiler';
+
+const { module, test } = QUnit;
+
+module('Environment');
+
+test('can be instantiated with new', function(assert) {
+  let env = new Environment({
+    document: self.document,
+    appendOperations: new DOMTreeConstruction(self.document)
+  });
+  assert.ok(env, 'environment exists');
+});
+
+test('can be instantiated with create', function(assert) {
+  let env = Environment.create();
+  assert.ok(env, 'environment exists');
+});
+
+test('can be assigned an owner', function(assert) {
+  class FakeApp implements Owner {
+    identify(specifier: string, referrer?: string) { return ''; }
+    factoryFor(specifier: string, referrer?: string) { return null; }
+    lookup(specifier: string, referrer?: string) { return null; }
+  }
+  let app = new FakeApp;
+
+  let options: EnvironmentOptions = {};
+  setOwner(options, app);
+
+  let env = Environment.create(options);
+  assert.strictEqual(getOwner(env), app, 'owner has been set');
+});
+
+test('can render a component', function(assert) {
+  class HelloWorld extends Component {
+  }
+
+  let helloWorldTemplate = precompile(
+    '<h1>Hello {{@name}}!</h1>', 
+    { meta: { specifier: 'template:/app/components/hello-world' }});
+
+  let mainTemplate = precompile(
+    '<hello-world @name={{salutation}} />', 
+    { meta: { specifier: 'template:/app/main/main' }});
+
+  class FakeApp implements Owner {
+    identify(specifier: string, referrer?: string): string {
+      if (specifier === 'component:hello-world' &&
+          referrer === 'template:/app/main/main') {
+        return 'component:/app/components/hello-world';
+      } else {
+        throw new Error('Unexpected');
+      }
+    }
+
+    factoryFor(specifier: string, referrer?: string): Factory<any> {
+      if (specifier === 'component:/app/components/hello-world') {
+        return HelloWorld;
+      } else {
+        throw new Error('Unexpected');
+      }
+    }
+  
+    lookup(specifier: string, referrer?: string): any {
+      if (specifier === 'template' && referrer === 'component:/app/components/hello-world') {
+        return helloWorldTemplate;
+      } else {
+        throw new Error('Unexpected');
+      }
+    }
+  }
+
+  let app = new FakeApp();
+  let env = Environment.create({[OWNER]: app});
+
+  let output = document.createElement('output');
+  env.begin();
+
+  let ref = new UpdatableReference({
+    salutation: 'Glimmer'
+  });
+
+  let mainLayout = templateFactory(mainTemplate).create(env);
+  mainLayout.render(ref, output, new DynamicScope());
+
+  env.commit();
+
+  assert.equal(output.innerText, 'Hello Glimmer!');
+});

--- a/test/test-helpers/compiler.ts
+++ b/test/test-helpers/compiler.ts
@@ -1,0 +1,11 @@
+import {
+  precompile as glimmerPrecompile,
+  PrecompileOptions
+} from "@glimmer/compiler";
+import { 
+  TemplateJavascript 
+} from "@glimmer/wire-format";
+
+export function precompile(template: string, options: PrecompileOptions): TemplateJavascript {
+  return JSON.parse(glimmerPrecompile(template, options));
+}


### PR DESCRIPTION
See https://github.com/glimmerjs/glimmer-component/pull/3

While making these breaking changes, it was also decided to make one more - the default export for this package is now Application. This will enable the following import:

```
import Application from '@glimmer/application';
```