### PR TITLE
Use public interface for `SymbolTable`

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -130,7 +130,7 @@ export default class Environment extends GlimmerEnvironment {
   getComponentDefinition(name: string[], symbolTable: SymbolTable): ComponentDefinition {
     let owner: Owner = getOwner(this);
     let relSpecifier: string = `component:${name.join('/')}`;
-    let referrer: string = symbolTable.meta.specifier;
+    let referrer: string = symbolTable.getMeta().specifier;
     let specifier = owner.identify(relSpecifier, referrer);
 
     if (!this.components[specifier]) {


### PR DESCRIPTION
`SymbolTable#meta` is not part of the public API for `SymbolTable`; this replaces that with `#getMeta`. I also ran into an issue where invoking a component from within an `{{#each` block threw an error because `symbolTable` here was a `BlockSymbolTable` which does not have a `meta` property. In this instance `getMeta()` properly looks at the parent symbol table for meta data.