### PR TITLE
Component manager discovery

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,52 +1,25 @@
 const build = require('@glimmer/build');
 const buildVendorPackage = require('@glimmer/build/lib/build-vendor-package');
+const packageDist = require('@glimmer/build/lib/package-dist');
 const funnel = require('broccoli-funnel');
 const path = require('path');
 
 module.exports = function() {
-  let buildOptions = {};
+  let vendorTrees = [
+    '@glimmer/compiler',
+    '@glimmer/di',
+    '@glimmer/object-reference',
+    '@glimmer/reference',
+    '@glimmer/runtime',
+    '@glimmer/syntax',
+    '@glimmer/util',
+    '@glimmer/wire-format'
+  ].map(packageDist);
 
-  if (process.env.EMBER_ENV === 'test') {
-    buildOptions.vendorTrees = [
-      buildVendorPackage('@glimmer/compiler', { 
-        external: ['babel-helpers', '@glimmer/syntax', '@glimmer/wire-format', '@glimmer/util'] }),
-      buildVendorPackage('@glimmer/di', { 
-        external: ['babel-helpers'] }),
-      buildVendorPackage('@glimmer/object-reference', { 
-        external: ['babel-helpers', '@glimmer/util', '@glimmer/reference'] }),
-      buildVendorPackage('@glimmer/reference', { 
-        external: ['babel-helpers', '@glimmer/util'] }),
-      buildVendorPackage('@glimmer/runtime', {
-        external: ['babel-helpers', 
-                  '@glimmer/util',
-                  '@glimmer/reference',
-                  '@glimmer/wire-format',
-                  '@glimmer/syntax']}),
-      buildVendorPackage('@glimmer/syntax', { 
-        external: ['babel-helpers', '@glimmer/util', 'handlebars', 'simple-html-tokenizer'] }),
-      buildVendorPackage('@glimmer/util', { 
-        external: ['babel-helpers'] }),
-      buildVendorPackage('@glimmer/wire-format', { 
-        external: ['@glimmer/util'] }),
-      buildVendorPackage('simple-html-tokenizer'),
-      funnel(path.dirname(require.resolve('handlebars/package')), { 
-        include: ['dist/handlebars.amd.js'] })
-    ];
-  }
+  vendorTrees.push(buildVendorPackage('simple-html-tokenizer'));
+  vendorTrees.push(funnel(path.dirname(require.resolve('handlebars/package')), { 
+    include: ['dist/handlebars.amd.js']
+  }));
 
-  return build(buildOptions);
-}
-
-function includeVendorPackage(name) {
-  // Resolve package's `package.json`, in case `main` is set and it points deep
-  // into a `dist` directory.
-  let packagePath = require.resolve(`${name}/package`);
-  packagePath = path.dirname(packagePath);
-
-  return funnel(packagePath, {
-    include: [
-      'dist/amd/es5/**/*.js',
-      'amd/es5/**/*.js'
-    ]
-  });
+  return build({ vendorTrees });
 }

--- a/package.json
+++ b/package.json
@@ -23,11 +23,12 @@
     "@glimmer/util": "^0.23.0-alpha.0"
   },
   "devDependencies": {
-    "@glimmer/build": "^0.3.3",
     "@glimmer/compiler": "^0.23.0-alpha.0",
     "@glimmer/object-reference": "^0.23.0-alpha.0",
     "@glimmer/wire-format": "^0.23.0-alpha.0",
     "ember-cli": "^1.0.0",
+    "@glimmer/build": "^0.6.0",
+    "ember-cli": "^2.12.0",
     "testem": "^1.13.0",
     "typescript": "^2.2.1"
   }

--- a/package.json
+++ b/package.json
@@ -18,16 +18,16 @@
   },
   "dependencies": {
     "@glimmer/di": "^0.1.9",
-    "@glimmer/reference": "^0.23.0-alpha.0",
-    "@glimmer/runtime": "^0.23.0-alpha.0",
-    "@glimmer/util": "^0.23.0-alpha.0"
+    "@glimmer/reference": "^0.23.0-alpha.2",
+    "@glimmer/runtime": "^0.23.0-alpha.2",
+    "@glimmer/util": "^0.23.0-alpha.2"
   },
   "devDependencies": {
-    "@glimmer/compiler": "^0.23.0-alpha.0",
-    "@glimmer/object-reference": "^0.23.0-alpha.0",
-    "@glimmer/wire-format": "^0.23.0-alpha.0",
-    "ember-cli": "^1.0.0",
     "@glimmer/build": "^0.6.0",
+    "@glimmer/compiler": "^0.23.0-alpha.2",
+    "@glimmer/object-reference": "^0.23.0-alpha.2",
+    "@glimmer/resolver": "^0.3.0",
+    "@glimmer/wire-format": "^0.23.0-alpha.2",
     "ember-cli": "^2.12.0",
     "testem": "^1.13.0",
     "typescript": "^2.2.1"

--- a/src/application.ts
+++ b/src/application.ts
@@ -3,9 +3,11 @@ import {
   Factory,
   Owner,
   Registry,
+  RegistryWriter,
   RegistryAccessor,
   Resolver,
-  setOwner
+  setOwner,
+  FactoryDefinition
 } from '@glimmer/di';
 import {
   Simple,
@@ -21,6 +23,11 @@ export interface ApplicationOptions {
   resolver: Resolver;
 }
 
+export interface InstanceInitializer {
+  name?: string;
+  initialize(app: RegistryWriter): void;
+}
+
 export default class Application implements Owner {
   public rootName: string;
   public rootElement: any;
@@ -29,6 +36,8 @@ export default class Application implements Owner {
   private _registry: Registry;
   private _container: Container;
   private _renderResult: any; // TODO - type
+  private _initializers: InstanceInitializer[] = [];
+  private _initialized = false;
 
   constructor(options: ApplicationOptions) {
     this.rootName = options.rootName;
@@ -44,14 +53,29 @@ export default class Application implements Owner {
     // Create ApplicationRegistry as a proxy to the underlying registry
     // that will only be available during `initialize`.
     let appRegistry = new ApplicationRegistry(this._registry, this.resolver);
-    this.initialize(appRegistry);
   }
 
-  initialize(registry: RegistryAccessor): void {
+  registerInstanceInitializer(initializer: InstanceInitializer) {
+    this._initializers.push(initializer);
+  }
+
+  initialize(): void {
+    let registry = this._registry;
+
     registry.register(`environment:/${this.rootName}/main/main`, Environment);
     registry.registerOption('template', 'instantiate', false);
+    registry.register(`document:/${this.rootName}/main/main`, document);
+    registry.registerOption('document', 'instantiate', false);
+    registry.registerInjection('environment', 'document', `document:/${this.rootName}/main/main`);
+    registry.registerInjection('component-manager', 'env', `environment:/${this.rootName}/main/main`);
 
-    // Override and extend to perform custom registrations
+    let initializers = this._initializers;
+    for (let i = 0; i < initializers.length; i++) {
+      initializers[i].initialize(this);
+    }
+
+    this._initialized = true;
+    this.initContainer();
   }
 
   initContainer(): void {
@@ -67,7 +91,7 @@ export default class Application implements Owner {
   }
 
   boot(): void {
-    this.initContainer();
+    this.initialize();
 
     this.env = this.lookup(`environment:/${this.rootName}/main/main`);
 
@@ -83,6 +107,8 @@ export default class Application implements Owner {
     this.env.begin();
 
     let mainTemplate = this.lookup(`template:/${this.rootName}/components/main`);
+    if (!mainTemplate) { throw new Error("Could not find main template."); }
+
     let mainLayout = templateFactory(mainTemplate).create(this.env);
     let templateIterator = mainLayout.render(null, this.rootElement, new DynamicScope());
     let result;
@@ -104,6 +130,30 @@ export default class Application implements Owner {
   /**
    * Owner interface implementation
    */
+
+  register(specifier: string, factory: FactoryDefinition<any>, options?: RegistrationOptions) {
+    if (this._initialized) {
+      throw new Error("You can't add new registrations after an application has booted. Use an initializer instead.");
+    }
+
+    this._registry.register(specifier, factory, options);
+  }
+
+  unregister(specifier: string) {
+    this._registry.unregister(specifier);
+  }
+
+  registerOption(specifier: string, option: string, value: any): void {
+    this._registry.registerOption(specifier, option, value);
+  }
+
+  unregisterOption(specifier: string, option: string): void {
+    this._registry.unregisterOption(specifier, option);
+  }
+
+  registerInjection(specifier: string, property: string, source: string): void {
+    this._registry.registerInjection(specifier, property, source);
+  }
 
   identify(specifier: string, referrer?: string): string {
     return this.resolver.identify(specifier, referrer);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { default, ApplicationOptions, InstanceInitializer } from './application';
+export { default, ApplicationOptions, Initializer } from './application';
 export { default as Environment } from './environment';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { default, ApplicationOptions } from './application';
+export { default, ApplicationOptions, InstanceInitializer } from './application';
 export { default as Environment } from './environment';

--- a/test/application-as-owner-test.ts
+++ b/test/application-as-owner-test.ts
@@ -33,7 +33,7 @@ test('#factoryFor - returns a registered factory', function(assert) {
 
   let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
 
-  app.registerInstanceInitializer({
+  app.registerInitializer({
     initialize(app) {
       app.register('component:/app/components/date-picker', DatePicker);
     }
@@ -103,7 +103,7 @@ test('#factoryFor - will use a resolver to locate a factory, even if one is regi
   let resolver = new FakeResolver();
 
   let app = new Application({ rootName: 'app', resolver });
-  app.registerInstanceInitializer({
+  app.registerInitializer({
     initialize(app) {
       app.register('foo:/app/foos/bar', Foo);
     }
@@ -129,7 +129,7 @@ test('#lookup - returns an instance created by the factory', function(assert) {
   }
 
   let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
-  app.registerInstanceInitializer({
+  app.registerInitializer({
     initialize(app) {
       app.register('foo:/app/foos/bar', FooBar);
     }
@@ -154,7 +154,7 @@ test('#lookup - caches looked up instances by default', function(assert) {
   }
 
   let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
-  app.registerInstanceInitializer({
+  app.registerInitializer({
     initialize(app) {
       app.register('foo:/app/foos/bar', FooBar);
     }
@@ -186,7 +186,7 @@ test('#lookup - will not cache lookups specified as non-singletons', function(as
   }
 
   let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
-  app.registerInstanceInitializer({
+  app.registerInitializer({
     initialize(app) {
       app.register('foo:/app/foos/bar', FooBar, { singleton: false });
     }
@@ -209,7 +209,7 @@ test('#lookup - returns the factory when registrations specify instantiate: fals
   let factory = {};
 
   let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
-  app.registerInstanceInitializer({
+  app.registerInitializer({
     initialize(app) {
       app.register('foo:/app/foos/bar', factory, { instantiate: false });
     }
@@ -275,7 +275,7 @@ test('#lookup - injects references registered by name', function(assert) {
 
   let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
 
-  app.registerInstanceInitializer({
+  app.registerInitializer({
     initialize(app) {
       app.register('foo:/app/foos/bar', FooBar);
       app.register('router:/app/root/main', Router);
@@ -313,7 +313,7 @@ test('#lookup - injects references registered by type', function(assert) {
 
   let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
 
-  app.registerInstanceInitializer({
+  app.registerInitializer({
     initialize(app) {
       app.register('foo:/app/foos/bar', FooBar);
       app.register('router:/app/root/main', Router);

--- a/test/application-as-owner-test.ts
+++ b/test/application-as-owner-test.ts
@@ -31,14 +31,15 @@ test('#factoryFor - returns a registered factory', function(assert) {
     static create() { return { foo: 'bar' }; }
   }
 
-  class App extends Application {
-    initialize(registry) {
-      super.initialize(registry);
-      registry.register('component:/app/components/date-picker', DatePicker);
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
+
+  app.registerInstanceInitializer({
+    initialize(app) {
+      app.register('component:/app/components/date-picker', DatePicker);
     }
-  }
-  let app = new App({ rootName: 'app', resolver: new BlankResolver });
-  app.initContainer();
+  });
+
+  app.initialize();
 
   let factory = app.factoryFor('component:/app/components/date-picker');
   assert.strictEqual(factory.class, DatePicker, 'expected factory.class was returned');
@@ -67,7 +68,8 @@ test('#factoryFor - will use a resolver to locate a factory', function(assert) {
 
   let resolver = new FakeResolver();
   let app = new Application({ rootName: 'app', resolver });
-  app.initContainer();
+
+  app.initialize();
 
   let factory = app.factoryFor('component:date-picker');
   assert.strictEqual(factory.class, DatePicker, 'expected factory was returned');
@@ -100,15 +102,14 @@ test('#factoryFor - will use a resolver to locate a factory, even if one is regi
 
   let resolver = new FakeResolver();
 
-  class App extends Application {
-    initialize(registry) {
-      super.initialize(registry);
-      registry.register('foo:/app/foos/bar', Foo);
+  let app = new Application({ rootName: 'app', resolver });
+  app.registerInstanceInitializer({
+    initialize(app) {
+      app.register('foo:/app/foos/bar', Foo);
     }
-  }
+  });
 
-  let app = new App({ rootName: 'app', resolver });
-  app.initContainer();
+  app.initialize();
 
   let factory = app.factoryFor('foo:bar');
   assert.strictEqual(factory.class, FooBar, 'factory from resolver was returned');
@@ -127,15 +128,15 @@ test('#lookup - returns an instance created by the factory', function(assert) {
     }
   }
 
-  class App extends Application {
-    initialize(registry) {
-      super.initialize(registry);
-      registry.register('foo:/app/foos/bar', FooBar);
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
+  app.registerInstanceInitializer({
+    initialize(app) {
+      app.register('foo:/app/foos/bar', FooBar);
     }
-  }
+  });
 
-  let app = new App({ rootName: 'app', resolver: new BlankResolver() });
-  app.initContainer();
+  app.initialize();
+
   let foobar = app.lookup('foo:/app/foos/bar');
   assert.strictEqual(foobar, instance, 'instance created');
 });
@@ -152,19 +153,19 @@ test('#lookup - caches looked up instances by default', function(assert) {
     }
   }
 
-  class App extends Application {
-    initialize(registry) {
-      super.initialize(registry);
-      registry.register('foo:/app/foos/bar', FooBar);
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
+  app.registerInstanceInitializer({
+    initialize(app) {
+      app.register('foo:/app/foos/bar', FooBar);
     }
-  }
+  });
 
-  let app = new App({ rootName: 'app', resolver: new BlankResolver() });
-  app.initContainer();
+  app.initialize();  
 
   let foo1 = app.lookup('foo:/app/foos/bar');
   assert.equal(createCounter, 1);
   let foo2 = app.lookup('foo:/app/foos/bar');
+
   assert.equal(createCounter, 1);
   assert.strictEqual(foo1, foo2);
 });
@@ -182,14 +183,16 @@ test('#lookup - will not cache lookups specified as non-singletons', function(as
   }
 
   class App extends Application {
-    initialize(registry) {
-      super.initialize(registry);
-      registry.register('foo:/app/foos/bar', FooBar, { singleton: false });
-    }
   }
 
-  let app = new App({ rootName: 'app', resolver: new BlankResolver() });
-  app.initContainer();
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
+  app.registerInstanceInitializer({
+    initialize(app) {
+      app.register('foo:/app/foos/bar', FooBar, { singleton: false });
+    }
+  });
+
+  app.initialize();
 
   let foo1 = app.lookup('foo:/app/foos/bar');
   assert.equal(createCounter, 1);
@@ -205,15 +208,14 @@ test('#lookup - returns the factory when registrations specify instantiate: fals
 
   let factory = {};
 
-  class App extends Application {
-    initialize(registry) {
-      super.initialize(registry);
-      registry.register('foo:/app/foos/bar', factory, { instantiate: false });
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
+  app.registerInstanceInitializer({
+    initialize(app) {
+      app.register('foo:/app/foos/bar', factory, { instantiate: false });
     }
-  }
+  });
 
-  let app = new App({ rootName: 'app', resolver: new BlankResolver() });
-  app.initContainer();
+  app.initialize();
 
   let foo1 = app.lookup('foo:/app/foos/bar');
   assert.strictEqual(foo1, factory);
@@ -242,7 +244,8 @@ test('#lookup - uses the resolver to locate a registration', function(assert) {
 
   let resolver = new FakeResolver();
   let app = new Application({ rootName: 'app', resolver });
-  app.initContainer();
+  app.initialize();
+
   let foo1 = app.lookup('foo:bar');
 
   assert.deepEqual(foo1, { foo: 'bar' }, 'expected factory was invoked');
@@ -270,17 +273,17 @@ test('#lookup - injects references registered by name', function(assert) {
     }
   }
 
-  class App extends Application {
-    initialize(registry) {
-      super.initialize(registry);
-      registry.register('foo:/app/foos/bar', FooBar);
-      registry.register('router:/app/root/main', Router);
-      registry.registerInjection('foo:/app/foos/bar', 'router', 'router:/app/root/main');
-    }
-  }
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
 
-  let app = new App({ rootName: 'app', resolver: new BlankResolver() });
-  app.initContainer();
+  app.registerInstanceInitializer({
+    initialize(app) {
+      app.register('foo:/app/foos/bar', FooBar);
+      app.register('router:/app/root/main', Router);
+      app.registerInjection('foo:/app/foos/bar', 'router', 'router:/app/root/main');
+    }
+  });
+
+  app.initialize();
 
   assert.strictEqual(app.lookup('foo:/app/foos/bar'), instance, 'instance returned');
   assert.strictEqual(instance['router'], router, 'injection has been applied to instance');
@@ -308,17 +311,17 @@ test('#lookup - injects references registered by type', function(assert) {
     }
   }
 
-  class App extends Application {
-    initialize(registry) {
-      super.initialize(registry);
-      registry.register('foo:/app/foos/bar', FooBar);
-      registry.register('router:/app/root/main', Router);
-      registry.registerInjection('foo:/app/foos/bar', 'router', 'router:/app/root/main');
-    }
-  }
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
 
-  let app = new App({ rootName: 'app', resolver: new BlankResolver() });
-  app.initContainer();
+  app.registerInstanceInitializer({
+    initialize(app) {
+      app.register('foo:/app/foos/bar', FooBar);
+      app.register('router:/app/root/main', Router);
+      app.registerInjection('foo:/app/foos/bar', 'router', 'router:/app/root/main');
+    }
+  });
+
+  app.initialize();
 
   assert.strictEqual(app.lookup('foo:/app/foos/bar'), instance, 'instance returned');
   assert.strictEqual(instance['router'], router, 'injection has been applied to instance');

--- a/test/initializers-test.ts
+++ b/test/initializers-test.ts
@@ -15,7 +15,7 @@ test('instance initializers run at initialization', function(assert) {
   let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
 
 
-  app.registerInstanceInitializer({
+  app.registerInitializer({
     initialize(app) {
       app.register('component:/my-app/components/my-component', Component);
     }
@@ -25,14 +25,4 @@ test('instance initializers run at initialization', function(assert) {
 
   assert.ok(app.lookup('component:/my-app/components/my-component'));
   assert.ok(app.lookup('component:/my-app/components/my-component') instanceof Component);
-});
-
-test('registry cannot be written to after initialization', function(assert) {
-  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
-
-  app.initialize();
-
-  assert.raises(() => {
-    app.register('component:/my-app/components/my-component', Component);
-  }, /You can't add new registrations after an application has booted. Use an initializer instead./);
 });

--- a/test/instance-initializers-test.ts
+++ b/test/instance-initializers-test.ts
@@ -1,0 +1,38 @@
+import Application from '../src/application';
+import { BlankResolver } from './test-helpers/resolvers';
+
+const { module, test } = QUnit;
+
+module('Application InstanceInitializers');
+
+class Component {
+  static create() {
+    return new Component();
+  }
+}
+
+test('instance initializers run at initialization', function(assert) {
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
+
+
+  app.registerInstanceInitializer({
+    initialize(app) {
+      app.register('component:/my-app/components/my-component', Component);
+    }
+  });
+
+  app.initialize();
+
+  assert.ok(app.lookup('component:/my-app/components/my-component'));
+  assert.ok(app.lookup('component:/my-app/components/my-component') instanceof Component);
+});
+
+test('registry cannot be written to after initialization', function(assert) {
+  let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
+
+  app.initialize();
+
+  assert.raises(() => {
+    app.register('component:/my-app/components/my-component', Component);
+  }, /You can't add new registrations after an application has booted. Use an initializer instead./);
+});

--- a/test/test-helpers/components.ts
+++ b/test/test-helpers/components.ts
@@ -37,6 +37,7 @@ export class TestComponentManager implements ComponentManager<TestComponent>, Co
   }
 
   create(environment: Environment, definition: TestComponentDefinition, args: Arguments): TestComponent {
+    if (!definition.componentFactory) { return; }
     return definition.componentFactory.create();
   }
 
@@ -60,6 +61,7 @@ export class TestComponentManager implements ComponentManager<TestComponent>, Co
   }
 
   didCreateElement(component: TestComponent, element: Element) {
+    if (!component) { return; }
     component.element = element;
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "experimentalDecorators": true,
     "inlineSources": true,
     "inlineSourceMap": true,
+    "noUnusedLocals": true,
     "declaration": true,
     "newLine": "LF",
     "outDir": "dist",


### PR DESCRIPTION
This PR removes the manual component manager registry system and replaces it with a system that looks up component managers through the container. This means that component managers are looked up lazily and only instantiated the first time a template with that manager is seen.

Additionally, this commit introduces instance initializers, and makes some tweaks to rationalize application initialization and boot. The application now implements the RegistryWriter interface, but only allows writing to the registry before initialization has completed.

Lastly, there are some changes to better support the template-only component case. In particular, component definitions are now cached internally based on the template specifier, not the component specifier.