### PR TITLE
Add `{{component` macro

### DIFF
--- a/src/dynamic-component.ts
+++ b/src/dynamic-component.ts
@@ -1,0 +1,76 @@
+import {
+  SymbolTable
+} from '@glimmer/interfaces';
+import {
+  RevisionTag,
+  PathReference,
+  TagWrapper
+} from '@glimmer/reference';
+import {
+  ComponentDefinition,
+  Environment as GlimmerEnvironment,
+  VM,
+  Arguments,
+  ComponentArgs,
+  UNDEFINED_REFERENCE
+} from '@glimmer/runtime';
+import {
+  Opaque,
+  Option
+} from '@glimmer/util';
+import * as WireFormat from '@glimmer/wire-format';
+
+export function blockComponentMacro(params, hash, template, inverse, builder) {
+  let definitionArgs: ComponentArgs = [params.slice(0, 1), null, null, null];
+  let args: ComponentArgs = [params.slice(1), hashToArgs(hash), template, inverse];
+
+  builder.component.dynamic(definitionArgs, dynamicComponentFor, args);
+
+  return true;
+}
+
+export function inlineComponentMacro(_name, params, hash, builder) {
+  let definitionArgs: ComponentArgs = [params!.slice(0, 1), null, null, null];
+  let args: ComponentArgs = [params!.slice(1), hashToArgs(hash), null, null];
+
+  builder.component.dynamic(definitionArgs, dynamicComponentFor, args);
+
+  return true;
+}
+
+function dynamicComponentFor(vm: VM, args: Arguments, symbolTable: SymbolTable): DynamicComponentReference {
+  let nameRef = args.positional.at(0);
+  let env = vm.env;
+
+  return new DynamicComponentReference(nameRef, env, symbolTable);
+}
+
+class DynamicComponentReference implements PathReference<ComponentDefinition<Opaque>> {
+  public tag: TagWrapper<RevisionTag>;
+
+  constructor(private nameRef: PathReference<Opaque>, private env: GlimmerEnvironment, private symbolTable: SymbolTable) {
+    this.tag = nameRef.tag;
+  }
+
+  value(): ComponentDefinition<Opaque> {
+    let { env, nameRef } = this;
+
+    let nameOrDef = nameRef.value();
+
+    if (typeof nameOrDef === 'string') {
+      return env.getComponentDefinition(nameOrDef, this.symbolTable);
+    }
+
+    return null;
+  }
+
+  get() {
+    return UNDEFINED_REFERENCE;
+  }
+}
+
+function hashToArgs(hash: Option<WireFormat.Core.Hash>): Option<WireFormat.Core.Hash> {
+  if (hash === null) return null;
+  let names = hash[0].map(key => `@${key}`);
+  return [names, hash[1]];
+}

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,39 +1,24 @@
 import {
-  ComponentClass,
   DOMChanges,
   DOMTreeConstruction,
   Environment as GlimmerEnvironment,
   Helper as GlimmerHelper,
+  InlineMacros,
   ModifierManager,
-  PartialDefinition,
-  Simple,
-  compileLayout,
-  CompiledDynamicProgram,
   templateFactory,
   ComponentDefinition,
   Component,
   ComponentManager,
-  Template
+  BlockMacros
 } from '@glimmer/runtime';
 import {
   Reference,
-  RevisionTag,
-  PathReference,
-  OpaqueIterator,
-  OpaqueIterable,
-  AbstractIterable,
-  IterationItem,
-  VOLATILE_TAG
+  OpaqueIterable
 } from "@glimmer/reference";
 import {
-  Dict,
   dict,
-  assign,
-  initializeGuid,
-  Opaque,
-  FIXME
+  Opaque
 } from '@glimmer/util';
-import { SerializedTemplate, SerializedTemplateWithLazyBlock } from '@glimmer/wire-format';
 import {
   getOwner,
   setOwner,
@@ -44,6 +29,10 @@ import Iterable from './iterable';
 import TemplateMeta from './template-meta';
 import ComponentDefinitionCreator from './component-definition-creator'
 import Application from "./application";
+import {
+  blockComponentMacro,
+  inlineComponentMacro
+ } from './dynamic-component';
 
 type KeyFor<T> = (item: Opaque, index: T) => string;
 
@@ -204,6 +193,19 @@ export default class Environment extends GlimmerEnvironment {
 
     return new Iterable(ref, keyFor);
   }
+
+  macros(): { blocks: BlockMacros, inlines: InlineMacros } {
+    let macros = super.macros();
+
+    populateMacros(macros.blocks, macros.inlines);
+
+    return macros;
+  }
+}
+
+function populateMacros(blocks: BlockMacros, inlines: InlineMacros): void {
+  blocks.add('component', blockComponentMacro);
+  inlines.add('component', inlineComponentMacro);
 }
 
 function canCreateComponentDefinition(manager: ComponentDefinitionCreator | ComponentManager<Component>): manager is ComponentDefinitionCreator {


### PR DESCRIPTION
Possibly needed for the web component wrapper. This adds the inline and block forms of the `{{component` macro.