### PR TITLE
Make the root reference configurable

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -11,11 +11,18 @@ import {
   Simple,
   templateFactory
 } from '@glimmer/runtime';
+import {
+  VersionedPathReference
+} from '@glimmer/reference';
+import {
+  UpdatableReference
+} from '@glimmer/object-reference';
 import ApplicationRegistry from './application-registry';
 import DynamicScope from './dynamic-scope';
 import Environment from './environment';
 
 export interface ApplicationOptions {
+  rootRef?: VersionedPathReference<object>;
   rootName: string;
   rootElement?: Simple.Element;
   resolver: Resolver;
@@ -27,6 +34,7 @@ export interface Initializer {
 }
 
 export default class Application implements Owner {
+  public rootRef: VersionedPathReference<object>;
   public rootName: string;
   public rootElement: any;
   public resolver: Resolver;
@@ -40,6 +48,7 @@ export default class Application implements Owner {
   constructor(options: ApplicationOptions) {
     this.rootName = options.rootName;
     this.rootElement = options.rootElement;
+    this.rootRef = options.rootRef;
     this.resolver = options.resolver;
   }
 
@@ -92,6 +101,10 @@ export default class Application implements Owner {
       self.document.body.appendChild(this.rootElement);
     }
 
+    if (!this.rootRef) {
+      this.rootRef = new UpdatableReference({});
+    }
+
     this.render();
   }
 
@@ -102,7 +115,7 @@ export default class Application implements Owner {
     if (!mainTemplate) { throw new Error("Could not find main template."); }
 
     let mainLayout = templateFactory(mainTemplate).create(this.env);
-    let templateIterator = mainLayout.render(null, this.rootElement, new DynamicScope());
+    let templateIterator = mainLayout.render(this.rootRef, this.rootElement, new DynamicScope());
     let result;
     do {
       result = templateIterator.next();


### PR DESCRIPTION
Allows us to set the root reference instead of hard-coding `null`.