### PR TITLE
Add `roots` prop to `Application`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,16 +21,16 @@
   },
   "dependencies": {
     "@glimmer/di": "^0.1.9",
-    "@glimmer/reference": "^0.23.0-alpha.2",
-    "@glimmer/runtime": "^0.23.0-alpha.2",
-    "@glimmer/util": "^0.23.0-alpha.2"
+    "@glimmer/reference": "^0.23.0-alpha.3",
+    "@glimmer/runtime": "^0.23.0-alpha.3",
+    "@glimmer/util": "^0.23.0-alpha.3"
   },
   "devDependencies": {
     "@glimmer/build": "^0.6.0",
-    "@glimmer/compiler": "^0.23.0-alpha.2",
-    "@glimmer/object-reference": "^0.23.0-alpha.2",
+    "@glimmer/compiler": "^0.23.0-alpha.3",
+    "@glimmer/object-reference": "^0.23.0-alpha.3",
     "@glimmer/resolver": "^0.3.0",
-    "@glimmer/wire-format": "^0.23.0-alpha.2",
+    "@glimmer/wire-format": "^0.23.0-alpha.3",
     "ember-cli": "^2.12.0",
     "testem": "^1.13.0",
     "typescript": "^2.2.1"

--- a/src/application.ts
+++ b/src/application.ts
@@ -12,6 +12,9 @@ import {
   templateFactory,
   RenderResult
 } from '@glimmer/runtime';
+import {
+  UpdatableReference
+} from '@glimmer/object-reference';
 import ApplicationRegistry from './application-registry';
 import DynamicScope from './dynamic-scope';
 import Environment from './environment';
@@ -32,6 +35,7 @@ export default class Application implements Owner {
   public rootElement: any;
   public resolver: Resolver;
   public env: Environment;
+  protected roots: object[] = [];
   private _registry: Registry;
   private _container: Container;
   private _renderResult: RenderResult;
@@ -107,7 +111,8 @@ export default class Application implements Owner {
     if (!mainTemplate) { throw new Error("Could not find main template."); }
 
     let mainLayout = templateFactory(mainTemplate).create(this.env);
-    let templateIterator = mainLayout.render(null, this.rootElement, new DynamicScope());
+    let rootRef = new UpdatableReference({ roots: this.roots });
+    let templateIterator = mainLayout.render(rootRef, this.rootElement, new DynamicScope());
     let result;
     do {
       result = templateIterator.next();


### PR DESCRIPTION
Allows us to do this in subclasses of `Application`:

```ts
class App extends Application {
  renderComponent(component, parent, nextSibling) {
    this.roots.push({ component, parent, nextSibling });
    this.rerender();
  }
}
```

Which allows us to do this in the main template:

```hbs
{{#each roots key="@index" as |root|}}
  {{#-in-element root.parent nextSibling=root.nextSibling}}
    {{component root.component}}
  {{/-in-element}}
{{/each}}
```

cc @chancancode 