### PR TITLE
{{action}} shouldn’t error in template-only components

### DIFF
--- a/src/helpers/action.ts
+++ b/src/helpers/action.ts
@@ -21,7 +21,7 @@ export default function buildAction(vm: VM, _args: Arguments) {
     // Invoke the function with the component as the context, the curried
     // arguments passed to `{{action}}`, and the arguments the bound function
     // was invoked with.
-    actionFunc.apply(componentRef.value(), curriedArgs);
+    actionFunc.apply(componentRef && componentRef.value(), curriedArgs);
   });
 }
 

--- a/test/action-test.ts
+++ b/test/action-test.ts
@@ -56,6 +56,8 @@ test('can curry arguments to actions', function(assert) {
 });
 
 test('actions can be passed and invoked with additional arguments', function(assert) {
+  assert.expect(2);
+
   let fakeEvent: any = {
     type: 'click'
   };

--- a/test/test-helpers/components.ts
+++ b/test/test-helpers/components.ts
@@ -15,7 +15,7 @@ export class TestComponent {
   }
 }
 
-class TestComponentDefinition extends ComponentDefinition<TestComponent> {
+export class TestComponentDefinition extends ComponentDefinition<TestComponent> {
   componentFactory: Factory<TestComponent>;
   template: Template<TemplateMeta>;
 
@@ -63,7 +63,7 @@ export class TestComponentManager implements ComponentManager<TestComponent>, Co
   }
 
   getSelf(component: TestComponent) {
-    return new UpdatableReference(component);
+    return component ? new UpdatableReference(component) : null;
   }
 
   didCreateElement(component: TestComponent, element: Element) {


### PR DESCRIPTION
This was trying to get the component to bind the action function, but template-only components may not have a component object and be passing through a function that has already been bound. Now we guard for the existence of the componentRef before trying to get its value. We also now return null for template-only components from `getSelf()`.