### PR TITLE
Fix rebuild issues.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -56,5 +56,17 @@ module.exports = function() {
     }));
   }
 
-  return build({ srcTrees, vendorTrees });
-}
+  return build({
+    srcTrees,
+    vendorTrees,
+    external: [
+      '@glimmer/di',
+      '@glimmer/runtime',
+      '@glimmer/object-reference',
+      '@glimmer/util',
+      '@glimmer/reference',
+      '@glimmer/resolver',
+      '@glimmer/compiler'
+    ]
+  });
+};

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -26,12 +26,15 @@ module.exports = function() {
     include: ['dist/handlebars.amd.js']
   }));
 
-  let tsAndJs = funnel(__dirname, {
-    include: ['src/**/*.ts', 'src/**/*.js']
+  let srcPath = path.join(__dirname, 'src');
+  let tsAndJs = funnel(srcPath, {
+    include: ['**/*.ts', '**/*.js'],
+    destDir: 'src'
   });
 
-  let templates = funnel(__dirname, {
-    include: ['src/**/*.hbs']
+  let templates = funnel(srcPath, {
+    include: ['**/*.hbs'],
+    destDir: 'src'
   });
 
   let compiledTemplates = new GlimmerTemplatePrecompiler(templates, {
@@ -47,8 +50,9 @@ module.exports = function() {
     let testsIndex = buildTestsIndex('test', 'index.ts');
 
     srcTrees.push(funnel(testsIndex, { destDir: 'test' }));
-    srcTrees.push(funnel(__dirname, {
-      include: ['test/**/*.ts']
+    srcTrees.push(funnel(path.join(__dirname, 'test'), {
+      include: ['**/*.ts'],
+      destDir: 'test'
     }));
   }
 


### PR DESCRIPTION
<details>
<summary>Previously, warnings would be issued for every build and errors would be triggered for every rebuild</summary>

Prior to these changes, every build would issue the following warnings:

```
'@glimmer/di' is imported by tmp/rollup-cache_path-mZiTITg9.tmp/@glimmer/application/application.js, but could not be resolved – treating it as an external dependency
'@glimmer/runtime' is imported by tmp/rollup-cache_path-mZiTITg9.tmp/@glimmer/application/application.js, but could not be resolved – treating it as an external dependency
'@glimmer/object-reference' is imported by tmp/rollup-cache_path-mZiTITg9.tmp/@glimmer/application/application.js, but could not be resolved – treating it as an external dependency
'@glimmer/util' is imported by tmp/rollup-cache_path-mZiTITg9.tmp/@glimmer/application/dynamic-scope.js, but could not be resolved – treating it as an external dependency
'@glimmer/runtime' is imported by tmp/rollup-cache_path-mZiTITg9.tmp/@glimmer/application/environment.js, but could not be resolved – treating it as an external dependency
'@glimmer/util' is imported by tmp/rollup-cache_path-mZiTITg9.tmp/@glimmer/application/environment.js, but could not be resolved – treating it as an external dependency
'@glimmer/di' is imported by tmp/rollup-cache_path-mZiTITg9.tmp/@glimmer/application/environment.js, but could not be resolved – treating it as an external dependency
'@glimmer/object-reference' is imported by tmp/rollup-cache_path-mZiTITg9.tmp/@glimmer/application/iterable.js, but could not be resolved – treating it as an external dependency
'@glimmer/runtime' is imported by tmp/rollup-cache_path-mZiTITg9.tmp/@glimmer/application/dynamic-component.js, but could not be resolved – treating it as an external dependency
'@glimmer/reference' is imported by tmp/rollup-cache_path-mZiTITg9.tmp/@glimmer/application/helpers/action.js, but could not be resolved – treating it as an external dependency
'@glimmer/reference' is imported by tmp/rollup-cache_path-mZiTITg9.tmp/@glimmer/application/helpers/user-helper.js, but could not be resolved – treating it as an external dependency
```

And every rebuild (e.g. running `ember s` or `ember test --server`) would result in the following errors after a rebuild:

```
The Broccoli Plugin: [Rollup: amd/es5/glimmer-application.js] failed with:
Error: Could not load @glimmer/di (imported by /Users/rjackson/src/open-source/glimmer-application/tmp/rollup-cache_path-mZiTITg9.tmp/@glimmer/application/application.js): ENOENT: n
o such file or directory, open '@glimmer/di'
    at /Users/rjackson/src/open-source/glimmer-application/node_modules/rollup/dist/rollup.js:9461:10
    at process._tickCallback (internal/process/next_tick.js:103:7)

The broccoli plugin was instantiated at:
    at Rollup.Plugin (/Users/rjackson/src/open-source/glimmer-application/node_modules/broccoli-plugin/index.js:7:31)
    at new Rollup (/Users/rjackson/src/open-source/glimmer-application/node_modules/broccoli-rollup/dist/index.js:74:72)
    at toNamedAMD (/Users/rjackson/src/open-source/glimmer-application/node_modules/@glimmer/build/lib/to-named-amd.js:19:10)
    at module.exports (/Users/rjackson/src/open-source/glimmer-application/node_modules/@glimmer/build/index.js:141:18)
    at module.exports (/Users/rjackson/src/open-source/glimmer-application/ember-cli-build.js:59:10)
    at Builder.setupBroccoliBuilder (/Users/rjackson/src/open-source/glimmer-application/node_modules/ember-cli/lib/models/builder.js:54:19)
    at new Builder (/Users/rjackson/src/open-source/glimmer-application/node_modules/ember-cli/lib/models/builder.js:33:10)
    at ServeTask.run (/Users/rjackson/src/open-source/glimmer-application/node_modules/ember-cli/lib/tasks/serve.js:15:19)
    at Win.checkIfSymlinksNeedToBeEnabled.then (/Users/rjackson/src/open-source/glimmer-application/node_modules/ember-cli/lib/commands/serve.js:78:29)
    at tryCatch (/Users/rjackson/src/open-source/glimmer-application/node_modules/rsvp/dist/rsvp.js:539:12)
```
</details>

---

This PR fixes those issues by:

* Ensuring that we do not force the `process.cwd()` to be watched (this results in infinite rebuilds due to `tmp` being within `process.cwd()`)
* Manually specifying the `externals` to be used with rollup.