### PR TITLE
Allow Application to receive document as option

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -47,6 +47,7 @@ module.exports = function() {
   ];
 
   if (isTest) {
+    vendorTrees.push(buildVendorPackage('simple-dom'));
     let testsIndex = buildTestsIndex('test', 'index.ts');
 
     srcTrees.push(funnel(testsIndex, { destDir: 'test' }));

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@glimmer/compiler": "^0.23.0-alpha.6",
     "@glimmer/wire-format": "^0.23.0-alpha.6",
     "ember-cli": "^2.12.0",
+    "simple-dom": "^0.3.2",
     "testem": "^1.13.0",
     "typescript": "^2.2.1"
   }

--- a/src/application.ts
+++ b/src/application.ts
@@ -29,6 +29,7 @@ function NOOP() {}
 export interface ApplicationOptions {
   rootName: string;
   resolver: Resolver;
+  document?: Simple.Document;
 }
 
 export interface Initializer {
@@ -46,6 +47,7 @@ export interface AppRoot {
 export default class Application implements Owner {
   public rootName: string;
   public resolver: Resolver;
+  public document: Simple.Document;
   public env: Environment;
   private _roots: AppRoot[] = [];
   private _rootsIndex: number = 0;
@@ -62,6 +64,7 @@ export default class Application implements Owner {
   constructor(options: ApplicationOptions) {
     this.rootName = options.rootName;
     this.resolver = options.resolver;
+    this.document = options.document || window.document;
     this._renderPromise = new Promise<void>(resolve => {
       this._afterRender = resolve;
     });
@@ -83,7 +86,7 @@ export default class Application implements Owner {
     registry.register(`environment:/${this.rootName}/main/main`, Environment);
     registry.registerOption('helper', 'instantiate', false);
     registry.registerOption('template', 'instantiate', false);
-    registry.register(`document:/${this.rootName}/main/main`, window.document as any);
+    registry.register(`document:/${this.rootName}/main/main`, this.document as any);
     registry.registerOption('document', 'instantiate', false);
     registry.registerInjection('environment', 'document', `document:/${this.rootName}/main/main`);
     registry.registerInjection('component-manager', 'env', `environment:/${this.rootName}/main/main`);
@@ -130,7 +133,7 @@ export default class Application implements Owner {
 
     let mainLayout = templateFactory(mainTemplate).create(this.env);
     let self = new UpdatableReference({ roots: this._roots });
-    let appendTo = document.body;
+    let appendTo = this.document.body;
     let dynamicScope = new DynamicScope();
     let templateIterator = mainLayout.render(self, appendTo, dynamicScope);
     let result;

--- a/test/application-test.ts
+++ b/test/application-test.ts
@@ -1,5 +1,6 @@
 import Application from '../src/application';
 import { BlankResolver } from './test-helpers/resolvers';
+import { Document } from 'simple-dom';
 
 const { module, test } = QUnit;
 
@@ -8,4 +9,15 @@ module('Application');
 test('can be instantiated', function(assert) {
   let app = new Application({ rootName: 'app', resolver: new BlankResolver });
   assert.ok(app, 'app exists');
+});
+
+test('accepts options for rootName, resolver and document', function(assert) {
+  const resolver = new BlankResolver;
+  let app = new Application({ rootName: 'app', resolver });
+  assert.equal(app.rootName, 'app');
+  assert.equal(app.resolver, resolver);
+  assert.equal(app.document, window.document, 'defaults to window document if document is not provided in options');
+  let customDocument = new Document();
+  app = new Application({ rootName: 'app', resolver, document: customDocument });
+  assert.equal(app.document, customDocument);
 });

--- a/test/render-component-test.ts
+++ b/test/render-component-test.ts
@@ -1,6 +1,8 @@
 import buildApp from './test-helpers/test-app';
+import SimpleDOM from 'simple-dom';
 
 const { module, test } = QUnit;
+const serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
 
 module('renderComponent');
 
@@ -118,5 +120,22 @@ test('renders multiple components in the same container in particular places', f
     app.renderComponent('hello-robbie', containerElement, nextSibling)
   ]).then(() => {
     assert.equal(containerElement.innerHTML, '<h1>Hello Robbie!</h1><aside></aside><h1>Hello Glimmer!</h1>');
+  });
+});
+
+test('renders a component using simple-dom', function(assert) {
+  assert.expect(1);
+
+  let customDocument = new SimpleDOM.Document();
+
+  let containerElement = customDocument.createElement('div');
+
+  let app = buildApp('test-app', { document: customDocument })
+    .template('hello-world', `<h1>Hello Glimmer!</h1>`)
+    .boot();
+
+  return app.renderComponent('hello-world', containerElement).then(() => {
+    let serializedHTML = serializer.serialize(containerElement);
+    assert.equal(serializedHTML, '<div><h1>Hello Glimmer!</h1></div>');
   });
 });


### PR DESCRIPTION
This allow some experimenting with Server Side Rendering. With this change it's possible to use `simple-dom` to render the application.

Also removes all the usages of `window.document` to use the new option.