### PR TITLE
Introduce @glimmer/component dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test": "ember test"
   },
   "dependencies": {
+    "@glimmer/component": "^0.3.10",
     "@glimmer/di": "^0.1.9",
     "@glimmer/object-reference": "^0.23.0-alpha.6",
     "@glimmer/reference": "^0.23.0-alpha.6",

--- a/src/component-definition-creator.ts
+++ b/src/component-definition-creator.ts
@@ -1,6 +1,6 @@
 import { Template, Component, ComponentDefinition } from '@glimmer/runtime';
 import { Factory } from '@glimmer/di';
-import TemplateMeta from './template-meta';
+import { TemplateMeta } from '@glimmer/component';
 
 interface ComponentDefinitionCreator {
   createComponentDefinition(name: string, template: Template<TemplateMeta>, componentFactory?: Factory<Component>): ComponentDefinition<Component>;

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -26,7 +26,7 @@ import {
   Factory
 } from '@glimmer/di';
 import Iterable from './iterable';
-import TemplateMeta from './template-meta';
+import { TemplateMeta } from '@glimmer/component';
 import ComponentDefinitionCreator from './component-definition-creator'
 import Application from "./application";
 import {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
 export { default, ApplicationOptions, Initializer, AppRoot } from './application';
 export { default as Environment } from './environment';
-export { default as TemplateMeta } from './template-meta';

--- a/src/template-meta.ts
+++ b/src/template-meta.ts
@@ -1,8 +1,0 @@
-import { TemplateMeta } from '@glimmer/wire-format';
-
-interface ExtendedTemplateMeta extends TemplateMeta {
-  specifier: string;
-  managerId?: string;
-}
-
-export default ExtendedTemplateMeta;

--- a/test/test-helpers/compiler.ts
+++ b/test/test-helpers/compiler.ts
@@ -5,7 +5,7 @@ import {
 import { 
   SerializedTemplateWithLazyBlock
 } from "@glimmer/wire-format";
-import TemplateMeta from '../../src/template-meta';
+import { TemplateMeta } from '@glimmer/component';
 
 export function precompile(template: string, options: PrecompileOptions<TemplateMeta>): SerializedTemplateWithLazyBlock<TemplateMeta> {
   return JSON.parse(glimmerPrecompile(template, options));

--- a/test/test-helpers/components.ts
+++ b/test/test-helpers/components.ts
@@ -2,7 +2,7 @@ import { ComponentManager, ComponentDefinition, Arguments, CompiledDynamicProgra
 import { Factory } from '@glimmer/di';
 import ComponentDefinitionCreator from '../../src/component-definition-creator';
 import Environment from "../../src/environment";
-import TemplateMeta from '../../src/template-meta';
+import { TemplateMeta } from '@glimmer/component';
 import { UpdatableReference } from '@glimmer/object-reference';
 
 export class TestComponent {


### PR DESCRIPTION
By moving TemplateMeta’s definition to @glimmer/component, we can make
@glimmer/component a dependency of @glimmer/application (instead of the
other way around).

Corresponding PR: https://github.com/glimmerjs/glimmer-component/pull/55