### PR TITLE
`didRender` test helper

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -57,6 +57,7 @@ export default class Application implements Owner {
   private _initialized = false;
   private _rendered = false;
   private _scheduled = false;
+  private _working = false;
   private _rerender: () => void = NOOP;
 
   constructor(options: ApplicationOptions) {
@@ -152,7 +153,6 @@ export default class Application implements Owner {
 
   _didRender(): void {
     this._rendered = true;
-
   }
 
   renderComponent(component: string | ComponentDefinition<Component>, parent: Simple.Node, nextSibling: Option<Simple.Node> = null): void {
@@ -161,12 +161,18 @@ export default class Application implements Owner {
   }
 
   scheduleRerender(): void {
-    if (this._scheduled || !this._rendered) return;
+    this._working = true;
+    
+    if (this._scheduled || !this._rendered) {
+      this._working = false;
+      return;
+    }
 
     this._scheduled = true;
     requestAnimationFrame(() => {
       this._scheduled = false;
       this._rerender();
+      this._working = false;
     });
   }
 

--- a/src/application.ts
+++ b/src/application.ts
@@ -58,16 +58,11 @@ export default class Application implements Owner {
   private _rendered = false;
   private _scheduled = false;
   private _rerender: () => void = NOOP;
-  private _afterRender: () => void = NOOP;
-  private _renderPromise: Option<Promise<void>>;
 
   constructor(options: ApplicationOptions) {
     this.rootName = options.rootName;
     this.resolver = options.resolver;
     this.document = options.document || window.document;
-    this._renderPromise = new Promise<void>(resolve => {
-      this._afterRender = resolve;
-    });
   }
 
   /** @hidden */
@@ -156,39 +151,16 @@ export default class Application implements Owner {
   }
 
   _didRender(): void {
-    let { _afterRender } = this;
-
-    this._afterRender = NOOP;
-    this._renderPromise = null;
     this._rendered = true;
 
-    _afterRender();
   }
 
-  renderComponent(
-    component: string | ComponentDefinition<Component>,
-    parent: Simple.Node,
-    nextSibling: Option<Simple.Node> = null
-  ): Promise<void> {
+  renderComponent(component: string | ComponentDefinition<Component>, parent: Simple.Node, nextSibling: Option<Simple.Node> = null): void {
     this._roots.push({ id: this._rootsIndex++, component, parent, nextSibling });
-    return this.scheduleRerender();
+    this.scheduleRerender();
   }
 
-  scheduleRerender(): Promise<void> {
-    let { _renderPromise } = this;
-
-    if (_renderPromise === null) {
-      _renderPromise = this._renderPromise = new Promise<void>(resolve => {
-        this._afterRender = resolve;
-      });
-
-      this._scheduleRerender();
-    }
-
-    return _renderPromise;
-  }
-
-  _scheduleRerender(): void {
+  scheduleRerender(): void {
     if (this._scheduled || !this._rendered) return;
 
     this._scheduled = true;

--- a/test/action-test.ts
+++ b/test/action-test.ts
@@ -1,12 +1,13 @@
 import { TestComponent } from './test-helpers/components';
 import buildApp from './test-helpers/test-app';
+import didRender from './test-helpers/did-render';
 import { debugInfoForReference } from '../src/helpers/action';
 
 const { module, test } = QUnit;
 
 module('Actions');
 
-test('can curry arguments to actions', function(assert) {
+test('can curry arguments to actions', async function(assert) {
   assert.expect(9);
 
   let fakeEvent: any = {};
@@ -47,6 +48,8 @@ test('can curry arguments to actions', function(assert) {
 
   helloWorldComponent.name = "cruel world";
   app.scheduleRerender();
+  
+  await didRender(app);
 
   h1 = app.rootElement.querySelector('h1');
   h1.onclick(fakeEvent);

--- a/test/environment-test.ts
+++ b/test/environment-test.ts
@@ -3,6 +3,7 @@ import { DOMTreeConstruction } from '@glimmer/runtime';
 import Environment, { EnvironmentOptions } from '../src/environment';
 import { TestComponent } from './test-helpers/components';
 import buildApp from './test-helpers/test-app';
+import didRender from './test-helpers/did-render';
 import SimpleDOM from 'simple-dom';
 
 const { module, test } = QUnit;
@@ -52,7 +53,7 @@ test('can render a component', function(assert) {
   assert.equal(app.rootElement.innerText, 'Hello Glimmer!');
 });
 
-test('can render a component with the component helper', function(assert) {
+test('can render a component with the component helper', async function(assert) {
   class MainComponent extends TestComponent {
     salutation = 'Glimmer';
   }
@@ -66,6 +67,8 @@ test('can render a component with the component helper', function(assert) {
   assert.equal(app.rootElement.innerText, 'Hello Glimmer!');
 
   app.scheduleRerender();
+
+  await didRender(app);
 
   assert.equal(app.rootElement.innerText, 'Hello Glimmer!');
 });
@@ -84,7 +87,7 @@ test('components without a template raise an error', function(assert) {
   }, /The component 'hello-world' is missing a template. All components must have a template. Make sure there is a template.hbs in the component directory./);
 });
 
-test('can render a custom helper', function(assert) {
+test('can render a custom helper', async function(assert) {
   class MainComponent extends TestComponent {
   }
 
@@ -97,11 +100,13 @@ test('can render a custom helper', function(assert) {
   assert.equal(app.rootElement.innerText, 'Hello Glimmer!');
 
   app.scheduleRerender();
+  
+  await didRender(app);
 
   assert.equal(app.rootElement.innerText, 'Hello Glimmer!');
 });
 
-test('can render a custom helper that takes args', function(assert) {
+test('can render a custom helper that takes args', async function(assert) {
   class MainComponent extends TestComponent {
     firstName = 'Tom'
     lastName = 'Dale'
@@ -116,6 +121,8 @@ test('can render a custom helper that takes args', function(assert) {
   assert.equal(app.rootElement.innerText, 'Hello Tom Dale!');
 
   app.scheduleRerender();
+  
+  await didRender(app);
 
   assert.equal(app.rootElement.innerText, 'Hello Tom Dale!');
 });

--- a/test/environment-test.ts
+++ b/test/environment-test.ts
@@ -1,11 +1,12 @@
 import { getOwner, setOwner, Owner } from '@glimmer/di';
 import { DOMTreeConstruction } from '@glimmer/runtime';
-
 import Environment, { EnvironmentOptions } from '../src/environment';
 import { TestComponent } from './test-helpers/components';
 import buildApp from './test-helpers/test-app';
+import SimpleDOM from 'simple-dom';
 
 const { module, test } = QUnit;
+const serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
 
 module('Environment');
 
@@ -119,3 +120,16 @@ test('can render a custom helper that takes args', function(assert) {
   assert.equal(app.rootElement.innerText, 'Hello Tom Dale!');
 });
 
+test('renders a component using simple-dom', function(assert) {
+  assert.expect(1);
+
+  let customDocument = new SimpleDOM.Document();
+
+  let app = buildApp('test-app', { document: customDocument })
+    .template('main', `<h1>Hello Glimmer!</h1>`)
+    .boot();
+
+  let serializedHTML = serializer.serialize(app.rootElement);
+
+  assert.equal(serializedHTML, '<div><h1>Hello Glimmer!</h1></div>');
+});

--- a/test/render-component-test.ts
+++ b/test/render-component-test.ts
@@ -1,10 +1,11 @@
 import buildApp from './test-helpers/test-app';
+import didRender from './test-helpers/did-render';
 
 const { module, test } = QUnit;
 
 module('renderComponent');
 
-test('renders a component', function(assert) {
+test('renders a component', async function(assert) {
   assert.expect(1);
 
   let containerElement = document.createElement('div');
@@ -13,12 +14,14 @@ test('renders a component', function(assert) {
     .template('hello-world', `<h1>Hello Glimmer!</h1>`)
     .boot();
 
-  return app.renderComponent('hello-world', containerElement).then(() => {
-    assert.equal(containerElement.innerHTML, '<h1>Hello Glimmer!</h1>');
-  });
+  app.renderComponent('hello-world', containerElement);
+
+  await didRender(app);
+
+  assert.equal(containerElement.innerHTML, '<h1>Hello Glimmer!</h1>');
 });
 
-test('renders a component without affecting existing content', function(assert) {
+test('renders a component without affecting existing content', async function(assert) {
   assert.expect(2);
 
   let containerElement = document.createElement('div');
@@ -34,12 +37,14 @@ test('renders a component without affecting existing content', function(assert) 
 
   assert.equal(containerElement.innerHTML, '<p>foo</p>bar');
 
-  return app.renderComponent('hello-world', containerElement).then(() => {
-    assert.equal(containerElement.innerHTML, '<p>foo</p>bar<h1>Hello Glimmer!</h1>');
-  });
+  app.renderComponent('hello-world', containerElement);
+
+  await didRender(app);
+
+  assert.equal(containerElement.innerHTML, '<p>foo</p>bar<h1>Hello Glimmer!</h1>');
 });
 
-test('renders a component before a given sibling', function(assert) {
+test('renders a component before a given sibling', async function(assert) {
   assert.expect(2);
 
   let containerElement = document.createElement('div');
@@ -55,12 +60,14 @@ test('renders a component before a given sibling', function(assert) {
 
   assert.equal(containerElement.innerHTML, '<p></p><aside></aside>');
 
-  return app.renderComponent('hello-world', containerElement, nextSibling).then(() => {
-    assert.equal(containerElement.innerHTML, '<p></p><h1>Hello Glimmer!</h1><aside></aside>');
-  });
+  app.renderComponent('hello-world', containerElement, nextSibling);
+
+  await didRender(app);
+
+  assert.equal(containerElement.innerHTML, '<p></p><h1>Hello Glimmer!</h1><aside></aside>');
 });
 
-test('renders multiple components in different places', function(assert) {
+test('renders multiple components in different places', async function(assert) {
   assert.expect(2);
 
   let firstContainerElement = document.createElement('div');
@@ -71,16 +78,16 @@ test('renders multiple components in different places', function(assert) {
     .template('hello-robbie', `<h1>Hello Robbie!</h1>`)
     .boot();
 
-  return Promise.all([
-    app.renderComponent('hello-world', firstContainerElement),
-    app.renderComponent('hello-robbie', secondContainerElement)
-  ]).then(() => {
-    assert.equal(firstContainerElement.innerHTML, '<h1>Hello Glimmer!</h1>');
-    assert.equal(secondContainerElement.innerHTML, '<h1>Hello Robbie!</h1>');
-  });
+  app.renderComponent('hello-world', firstContainerElement),
+  app.renderComponent('hello-robbie', secondContainerElement)
+
+  await didRender(app);
+
+  assert.equal(firstContainerElement.innerHTML, '<h1>Hello Glimmer!</h1>');
+  assert.equal(secondContainerElement.innerHTML, '<h1>Hello Robbie!</h1>');
 });
 
-test('renders multiple components in the same container', function(assert) {
+test('renders multiple components in the same container', async function(assert) {
   assert.expect(1);
 
   let containerElement = document.createElement('div');
@@ -90,15 +97,15 @@ test('renders multiple components in the same container', function(assert) {
     .template('hello-robbie', `<h1>Hello Robbie!</h1>`)
     .boot();
 
-  return Promise.all([
-    app.renderComponent('hello-world', containerElement),
-    app.renderComponent('hello-robbie', containerElement)
-  ]).then(() => {
-    assert.equal(containerElement.innerHTML, '<h1>Hello Glimmer!</h1><h1>Hello Robbie!</h1>');
-  });
+  app.renderComponent('hello-world', containerElement),
+  app.renderComponent('hello-robbie', containerElement)
+
+  await didRender(app);
+
+  assert.equal(containerElement.innerHTML, '<h1>Hello Glimmer!</h1><h1>Hello Robbie!</h1>');
 });
 
-test('renders multiple components in the same container in particular places', function(assert) {
+test('renders multiple components in the same container in particular places', async function(assert) {
   assert.expect(2);
 
   let containerElement = document.createElement('div');
@@ -113,13 +120,10 @@ test('renders multiple components in the same container in particular places', f
 
   assert.equal(containerElement.innerHTML, '<aside></aside>');
 
-  return Promise.all([
-    app.renderComponent('hello-world', containerElement),
-    app.renderComponent('hello-robbie', containerElement, nextSibling)
-  ]).then(() => {
-    assert.equal(containerElement.innerHTML, '<h1>Hello Robbie!</h1><aside></aside><h1>Hello Glimmer!</h1>');
-  });
-});
+  app.renderComponent('hello-world', containerElement),
+  app.renderComponent('hello-robbie', containerElement, nextSibling)
 
+  await didRender(app);
 
+  assert.equal(containerElement.innerHTML, '<h1>Hello Robbie!</h1><aside></aside><h1>Hello Glimmer!</h1>');
 });

--- a/test/render-component-test.ts
+++ b/test/render-component-test.ts
@@ -1,8 +1,6 @@
 import buildApp from './test-helpers/test-app';
-import SimpleDOM from 'simple-dom';
 
 const { module, test } = QUnit;
-const serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
 
 module('renderComponent');
 
@@ -123,19 +121,5 @@ test('renders multiple components in the same container in particular places', f
   });
 });
 
-test('renders a component using simple-dom', function(assert) {
-  assert.expect(1);
 
-  let customDocument = new SimpleDOM.Document();
-
-  let containerElement = customDocument.createElement('div');
-
-  let app = buildApp('test-app', { document: customDocument })
-    .template('hello-world', `<h1>Hello Glimmer!</h1>`)
-    .boot();
-
-  return app.renderComponent('hello-world', containerElement).then(() => {
-    let serializedHTML = serializer.serialize(containerElement);
-    assert.equal(serializedHTML, '<div><h1>Hello Glimmer!</h1></div>');
-  });
 });

--- a/test/test-helpers/did-render.ts
+++ b/test/test-helpers/did-render.ts
@@ -3,7 +3,7 @@ import Application from '../../src/application';
 async function didRender(app: Application): Promise<void> {
   return new Promise<void>(resolve => {
     let watcher = setInterval(function() {
-      if (app['_scheduled']) return;
+      if (app['_working']) return;
       clearInterval(watcher);
       resolve();
     }, 10);

--- a/test/test-helpers/did-render.ts
+++ b/test/test-helpers/did-render.ts
@@ -1,6 +1,6 @@
 import Application from '../../src/application';
 
-export default async function didRender(app: Application): Promise<void> {
+async function didRender(app: Application): Promise<void> {
   return new Promise<void>(resolve => {
     let watcher = setInterval(function() {
       if (app['_scheduled']) return;
@@ -8,4 +8,6 @@ export default async function didRender(app: Application): Promise<void> {
       resolve();
     }, 10);
   });
-}
+};
+
+export default didRender;

--- a/test/test-helpers/did-render.ts
+++ b/test/test-helpers/did-render.ts
@@ -1,0 +1,11 @@
+import Application from '../../src/application';
+
+export default async function didRender(app: Application): Promise<void> {
+  return new Promise<void>(resolve => {
+    let watcher = setInterval(function() {
+      if (app['_scheduled']) return;
+      clearInterval(watcher);
+      resolve();
+    }, 10);
+  });
+}

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target": "es2015",
     "module": "es2015",
     "experimentalDecorators": true,
     "moduleResolution": "node",


### PR DESCRIPTION
We do not need a hook on `Application` nor do we need `renderComponent` to return a promise. All we need is this helper. It is essentially a reduced version of the Ember `wait` helper.

Usage is simple:

```typescript
test('renders a component', async function(assert) {
  // ...

  app.renderComponent('hello-world', containerElement);

  await didRender(app);

  assert.equal(containerElement.innerHTML, '<h1>Hello Glimmer!</h1>');
});
```

Note: this PR removes the `Promise` stuff around `renderComponent` since it is not necessary.