### PR TITLE
`_rendering` flag so we know when `Application` is working on a rerender

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@glimmer/util": "^0.23.0-alpha.6"
   },
   "devDependencies": {
-    "@glimmer/application-test-helpers": "^0.1.3",
+    "@glimmer/application-test-helpers": "^0.1.4",
     "@glimmer/build": "^0.6.2",
     "@glimmer/compiler": "^0.23.0-alpha.6",
     "@glimmer/wire-format": "^0.23.0-alpha.6",

--- a/src/application.ts
+++ b/src/application.ts
@@ -55,6 +55,7 @@ export default class Application implements Owner {
   private _container: Container;
   private _initializers: Initializer[] = [];
   private _initialized = false;
+  private _rendering = false;
   private _rendered = false;
   private _scheduled = false;
   private _rerender: () => void = NOOP;
@@ -153,7 +154,6 @@ export default class Application implements Owner {
 
   _didRender(): void {
     this._rendered = true;
-
   }
 
   renderComponent(component: string | ComponentDefinition<Component>, parent: Simple.Node, nextSibling: Option<Simple.Node> = null): void {
@@ -164,10 +164,12 @@ export default class Application implements Owner {
   scheduleRerender(): void {
     if (this._scheduled || !this._rendered) return;
 
+    this._rendering = true;
     this._scheduled = true;
     requestAnimationFrame(() => {
       this._scheduled = false;
       this._rerender();
+      this._rendering = false;
     });
   }
 

--- a/src/application.ts
+++ b/src/application.ts
@@ -58,16 +58,11 @@ export default class Application implements Owner {
   private _rendered = false;
   private _scheduled = false;
   private _rerender: () => void = NOOP;
-  private _afterRender: () => void = NOOP;
-  private _renderPromise: Option<Promise<void>>;
 
   constructor(options: ApplicationOptions) {
     this.rootName = options.rootName;
     this.resolver = options.resolver;
     this.document = options.document || window.document;
-    this._renderPromise = new Promise<void>(resolve => {
-      this._afterRender = resolve;
-    });
   }
 
   /** @hidden */
@@ -157,39 +152,16 @@ export default class Application implements Owner {
   }
 
   _didRender(): void {
-    let { _afterRender } = this;
-
-    this._afterRender = NOOP;
-    this._renderPromise = null;
     this._rendered = true;
 
-    _afterRender();
   }
 
-  renderComponent(
-    component: string | ComponentDefinition<Component>,
-    parent: Simple.Node,
-    nextSibling: Option<Simple.Node> = null
-  ): Promise<void> {
+  renderComponent(component: string | ComponentDefinition<Component>, parent: Simple.Node, nextSibling: Option<Simple.Node> = null): void {
     this._roots.push({ id: this._rootsIndex++, component, parent, nextSibling });
-    return this.scheduleRerender();
+    this.scheduleRerender();
   }
 
-  scheduleRerender(): Promise<void> {
-    let { _renderPromise } = this;
-
-    if (_renderPromise === null) {
-      _renderPromise = this._renderPromise = new Promise<void>(resolve => {
-        this._afterRender = resolve;
-      });
-
-      this._scheduleRerender();
-    }
-
-    return _renderPromise;
-  }
-
-  _scheduleRerender(): void {
+  scheduleRerender(): void {
     if (this._scheduled || !this._rendered) return;
 
     this._scheduled = true;

--- a/test/action-test.ts
+++ b/test/action-test.ts
@@ -1,12 +1,13 @@
 import Component, { tracked } from '@glimmer/component';
 import buildApp from './test-helpers/test-app';
+import { didRender } from '@glimmer/application-test-helpers';
 import { debugInfoForReference } from '../src/helpers/action';
 
 const { module, test } = QUnit;
 
 module('Actions');
 
-test('can curry arguments to actions', function(assert) {
+test('can curry arguments to actions', async function(assert) {
   assert.expect(9);
 
   let fakeEvent: any = {};
@@ -49,6 +50,8 @@ test('can curry arguments to actions', function(assert) {
 
   helloWorldComponent.name = "cruel world";
   app.scheduleRerender();
+
+  await didRender(app);
 
   h1 = root.querySelector('h1');
   h1.onclick(fakeEvent);

--- a/test/render-component-test.ts
+++ b/test/render-component-test.ts
@@ -1,12 +1,11 @@
 import buildApp from './test-helpers/test-app';
-import SimpleDOM from 'simple-dom';
+import { didRender } from '@glimmer/application-test-helpers';
 
 const { module, test } = QUnit;
-const serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
 
 module('renderComponent');
 
-test('renders a component', function(assert) {
+test('renders a component', async function(assert) {
   assert.expect(1);
 
   let containerElement = document.createElement('div');
@@ -15,12 +14,14 @@ test('renders a component', function(assert) {
     .template('hello-world', `<h1>Hello Glimmer!</h1>`)
     .boot();
 
-  return app.renderComponent('hello-world', containerElement).then(() => {
-    assert.equal(containerElement.innerHTML, '<h1>Hello Glimmer!</h1>');
-  });
+  app.renderComponent('hello-world', containerElement);
+
+  await didRender(app);
+
+  assert.equal(containerElement.innerHTML, '<h1>Hello Glimmer!</h1>');
 });
 
-test('renders a component without affecting existing content', function(assert) {
+test('renders a component without affecting existing content', async function(assert) {
   assert.expect(2);
 
   let containerElement = document.createElement('div');
@@ -36,12 +37,14 @@ test('renders a component without affecting existing content', function(assert) 
 
   assert.equal(containerElement.innerHTML, '<p>foo</p>bar');
 
-  return app.renderComponent('hello-world', containerElement).then(() => {
-    assert.equal(containerElement.innerHTML, '<p>foo</p>bar<h1>Hello Glimmer!</h1>');
-  });
+  app.renderComponent('hello-world', containerElement);
+
+  await didRender(app);
+
+  assert.equal(containerElement.innerHTML, '<p>foo</p>bar<h1>Hello Glimmer!</h1>');
 });
 
-test('renders a component before a given sibling', function(assert) {
+test('renders a component before a given sibling', async function(assert) {
   assert.expect(2);
 
   let containerElement = document.createElement('div');
@@ -57,12 +60,14 @@ test('renders a component before a given sibling', function(assert) {
 
   assert.equal(containerElement.innerHTML, '<p></p><aside></aside>');
 
-  return app.renderComponent('hello-world', containerElement, nextSibling).then(() => {
-    assert.equal(containerElement.innerHTML, '<p></p><h1>Hello Glimmer!</h1><aside></aside>');
-  });
+  app.renderComponent('hello-world', containerElement, nextSibling);
+
+  await didRender(app);
+
+  assert.equal(containerElement.innerHTML, '<p></p><h1>Hello Glimmer!</h1><aside></aside>');
 });
 
-test('renders multiple components in different places', function(assert) {
+test('renders multiple components in different places', async function(assert) {
   assert.expect(2);
 
   let firstContainerElement = document.createElement('div');
@@ -73,16 +78,16 @@ test('renders multiple components in different places', function(assert) {
     .template('hello-robbie', `<h1>Hello Robbie!</h1>`)
     .boot();
 
-  return Promise.all([
-    app.renderComponent('hello-world', firstContainerElement),
-    app.renderComponent('hello-robbie', secondContainerElement)
-  ]).then(() => {
-    assert.equal(firstContainerElement.innerHTML, '<h1>Hello Glimmer!</h1>');
-    assert.equal(secondContainerElement.innerHTML, '<h1>Hello Robbie!</h1>');
-  });
+  app.renderComponent('hello-world', firstContainerElement),
+  app.renderComponent('hello-robbie', secondContainerElement)
+
+  await didRender(app);
+
+  assert.equal(firstContainerElement.innerHTML, '<h1>Hello Glimmer!</h1>');
+  assert.equal(secondContainerElement.innerHTML, '<h1>Hello Robbie!</h1>');
 });
 
-test('renders multiple components in the same container', function(assert) {
+test('renders multiple components in the same container', async function(assert) {
   assert.expect(1);
 
   let containerElement = document.createElement('div');
@@ -92,15 +97,15 @@ test('renders multiple components in the same container', function(assert) {
     .template('hello-robbie', `<h1>Hello Robbie!</h1>`)
     .boot();
 
-  return Promise.all([
-    app.renderComponent('hello-world', containerElement),
-    app.renderComponent('hello-robbie', containerElement)
-  ]).then(() => {
-    assert.equal(containerElement.innerHTML, '<h1>Hello Glimmer!</h1><h1>Hello Robbie!</h1>');
-  });
+  app.renderComponent('hello-world', containerElement),
+  app.renderComponent('hello-robbie', containerElement)
+
+  await didRender(app);
+
+  assert.equal(containerElement.innerHTML, '<h1>Hello Glimmer!</h1><h1>Hello Robbie!</h1>');
 });
 
-test('renders multiple components in the same container in particular places', function(assert) {
+test('renders multiple components in the same container in particular places', async function(assert) {
   assert.expect(2);
 
   let containerElement = document.createElement('div');
@@ -115,27 +120,10 @@ test('renders multiple components in the same container in particular places', f
 
   assert.equal(containerElement.innerHTML, '<aside></aside>');
 
-  return Promise.all([
-    app.renderComponent('hello-world', containerElement),
-    app.renderComponent('hello-robbie', containerElement, nextSibling)
-  ]).then(() => {
-    assert.equal(containerElement.innerHTML, '<h1>Hello Robbie!</h1><aside></aside><h1>Hello Glimmer!</h1>');
-  });
-});
+  app.renderComponent('hello-world', containerElement),
+  app.renderComponent('hello-robbie', containerElement, nextSibling)
 
-test('renders a component using simple-dom', function(assert) {
-  assert.expect(1);
+  await didRender(app);
 
-  let customDocument = new SimpleDOM.Document();
-
-  let containerElement = customDocument.createElement('div');
-
-  let app = buildApp('test-app', { document: customDocument })
-    .template('hello-world', `<h1>Hello Glimmer!</h1>`)
-    .boot();
-
-  return app.renderComponent('hello-world', containerElement).then(() => {
-    let serializedHTML = serializer.serialize(containerElement);
-    assert.equal(serializedHTML, '<div><h1>Hello Glimmer!</h1></div>');
-  });
+  assert.equal(containerElement.innerHTML, '<h1>Hello Robbie!</h1><aside></aside><h1>Hello Glimmer!</h1>');
 });

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target": "es2015",
     "module": "es2015",
     "experimentalDecorators": true,
     "moduleResolution": "node",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,14 @@
 # yarn lockfile v1
 
 
-"@glimmer/application-test-helpers@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@glimmer/application-test-helpers/-/application-test-helpers-0.1.2.tgz#aa9236d97e37a12a47d5a4d5344e5e4fdc7d7bfa"
+"@glimmer/application-test-helpers@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.npmjs.org/@glimmer/application-test-helpers/-/application-test-helpers-0.1.4.tgz#c3dcf2e8d385f7dff9d33852a5621f8982aa0551"
   dependencies:
     "@glimmer/compiler" "^0.23.0-alpha.6"
     "@glimmer/di" "^0.1.9"
     "@glimmer/env" "^0.1.7"
+    "@glimmer/interfaces" "^0.23.0-alpha.6"
     "@glimmer/object-reference" "^0.23.0-alpha.6"
     "@glimmer/reference" "^0.23.0-alpha.6"
     "@glimmer/resolver" "^0.3.0"
@@ -99,15 +100,11 @@
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.2.0.tgz#73bfd4a6ee4148a80bf092e8a5d29bcac9d4ce7e"
 
-"@glimmer/env@0.1.7", "@glimmer/env@^0.1.7":
+"@glimmer/env@^0.1.5", "@glimmer/env@^0.1.7":
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
 
-"@glimmer/env@^0.1.5":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.6.tgz#c57bd9fc99f39006293fb5c156dca192a635515e"
-
-"@glimmer/interfaces@^0.23.0-alpha.11":
+"@glimmer/interfaces@^0.23.0-alpha.11", "@glimmer/interfaces@^0.23.0-alpha.6":
   version "0.23.0-alpha.11"
   resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.23.0-alpha.11.tgz#18454766efb4e545e74eb8efdf2d17eea81f1394"
   dependencies:


### PR DESCRIPTION
Relies on with https://github.com/glimmerjs/glimmer-application-test-helpers/pull/1. Once that is merged and released (presumably 0.2.0) I'll need to update the lockfile here.

Also gets rid of the `renderComponent` promise stuff.