### PR TITLE
Adds `tslint` and fixes some linting errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "preversion": "npm test",
     "prepublish": "npm run build",
     "postpublish": "git push origin master --tags",
-    "test": "ember test",
+    "test": "npm run tslint && ember test",
+    "tslint": "tslint --typecheck -c tslint.json --project tsconfig.json",
+    "tslint:format": "tslint --typecheck -c tslint.json --project tsconfig.json --fix",
     "problems": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
@@ -41,6 +43,7 @@
     "ember-cli": "^2.12.0",
     "simple-dom": "^0.3.2",
     "testem": "^1.13.0",
+    "tslint": "^5.2.0",
     "typescript": "^2.2.1"
   }
 }

--- a/src/application.ts
+++ b/src/application.ts
@@ -38,10 +38,10 @@ export interface Initializer {
 }
 
 export interface AppRoot {
-  id: number,
-  component: string | ComponentDefinition<Component>,
-  parent: Simple.Node,
-  nextSibling: Option<Simple.Node>
+  id: number;
+  component: string | ComponentDefinition<Component>;
+  parent: Simple.Node;
+  nextSibling: Option<Simple.Node>;
 }
 
 export default class Application implements Owner {
@@ -50,7 +50,7 @@ export default class Application implements Owner {
   public document: Simple.Document;
   public env: Environment;
   private _roots: AppRoot[] = [];
-  private _rootsIndex: number = 0;
+  private _rootsIndex = 0;
   private _registry: Registry;
   private _container: Container;
   private _initializers: Initializer[] = [];
@@ -105,7 +105,7 @@ export default class Application implements Owner {
       let hash = {};
       setOwner(hash, this);
       return hash;
-    }
+    };
   }
 
   /** @hidden */

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -27,7 +27,7 @@ import {
 } from '@glimmer/di';
 import Iterable from './iterable';
 import { TemplateMeta } from '@glimmer/component';
-import ComponentDefinitionCreator from './component-definition-creator'
+import ComponentDefinitionCreator from './component-definition-creator';
 import Application from "./application";
 import {
   blockComponentMacro,
@@ -112,7 +112,7 @@ export default class Environment extends GlimmerEnvironment {
 
   getComponentDefinition(name: string, meta: TemplateMeta): ComponentDefinition<Component> {
     let owner: Owner = getOwner(this);
-    let relSpecifier: string = `template:${name}`;
+    let relSpecifier = `template:${name}`;
     let referrer: string = meta.specifier;
 
     let specifier = owner.identify(relSpecifier, referrer);
@@ -165,7 +165,7 @@ export default class Environment extends GlimmerEnvironment {
     }
 
     let owner: Owner = getOwner(this);
-    let relSpecifier: string = `helper:${name}`;
+    let relSpecifier = `helper:${name}`;
     let referrer: string = meta.specifier;
 
     let specifier = owner.identify(relSpecifier, referrer);

--- a/src/helpers/action.ts
+++ b/src/helpers/action.ts
@@ -34,7 +34,7 @@ export function debugInfoForReference(reference: any): string {
   let parent;
   let property;
 
-  if (reference == null) { return message; }
+  if (reference === null) { return message; }
 
   if ('parent' in reference && 'property' in reference) {
     parent = reference['parent'].value();
@@ -53,7 +53,7 @@ export function debugInfoForReference(reference: any): string {
 
 function debugName(obj: any) {
   let objType = typeof obj;
-  if (obj == null) {
+  if (obj === null) {
     return objType;
   } else if (objType === 'number' || objType === 'boolean') {
     return obj.toString();

--- a/test/action-test.ts
+++ b/test/action-test.ts
@@ -118,7 +118,7 @@ test('action helper invoked without a function raises an error', function(assert
 test('debug name from references can be extracted', function(assert) {
   let refOne = {
     parent: {
-      value() { return { debugName: 'parent' } }
+      value() { return { debugName: 'parent' }; }
     },
     property: 'name'
   };

--- a/test/environment-test.ts
+++ b/test/environment-test.ts
@@ -79,7 +79,7 @@ test('can render a component with the component helper', async function(assert) 
 
 test('components without a template raise an error', function(assert) {
   class HelloWorldComponent extends Component {
-    debugName: 'hello-world'
+    debugName: 'hello-world';
   }
 
   let app = buildApp()
@@ -106,7 +106,7 @@ test('can render a custom helper', async function(assert) {
   assert.equal(root.innerText, 'Hello Glimmer!');
 
   app.scheduleRerender();
-  
+
   await didRender(app);
 
   assert.equal(root.innerText, 'Hello Glimmer!');
@@ -114,8 +114,8 @@ test('can render a custom helper', async function(assert) {
 
 test('can render a custom helper that takes args', async function(assert) {
   class MainComponent extends Component {
-    firstName = 'Tom'
-    lastName = 'Dale'
+    firstName = 'Tom';
+    lastName = 'Dale';
   }
 
   let app = buildApp()
@@ -129,7 +129,7 @@ test('can render a custom helper that takes args', async function(assert) {
   assert.equal(root.innerText, 'Hello Tom Dale!');
 
   app.scheduleRerender();
-  
+
   await didRender(app);
 
   assert.equal(root.innerText, 'Hello Tom Dale!');

--- a/test/initializers-test.ts
+++ b/test/initializers-test.ts
@@ -14,7 +14,6 @@ class Component {
 test('instance initializers run at initialization', function(assert) {
   let app = new Application({ rootName: 'app', resolver: new BlankResolver() });
 
-
   app.registerInitializer({
     initialize(app) {
       app.register('component:/my-app/components/my-component', Component);

--- a/test/render-component-test.ts
+++ b/test/render-component-test.ts
@@ -79,7 +79,7 @@ test('renders multiple components in different places', async function(assert) {
     .boot();
 
   app.renderComponent('hello-world', firstContainerElement),
-  app.renderComponent('hello-robbie', secondContainerElement)
+  app.renderComponent('hello-robbie', secondContainerElement);
 
   await didRender(app);
 
@@ -98,7 +98,7 @@ test('renders multiple components in the same container', async function(assert)
     .boot();
 
   app.renderComponent('hello-world', containerElement),
-  app.renderComponent('hello-robbie', containerElement)
+  app.renderComponent('hello-robbie', containerElement);
 
   await didRender(app);
 
@@ -121,7 +121,7 @@ test('renders multiple components in the same container in particular places', a
   assert.equal(containerElement.innerHTML, '<aside></aside>');
 
   app.renderComponent('hello-world', containerElement),
-  app.renderComponent('hello-robbie', containerElement, nextSibling)
+  app.renderComponent('hello-robbie', containerElement, nextSibling);
 
   await didRender(app);
 

--- a/test/test-helpers/resolvers.ts
+++ b/test/test-helpers/resolvers.ts
@@ -1,7 +1,7 @@
 import { Resolver, isSpecifierStringAbsolute } from '@glimmer/di';
 
 export class BlankResolver implements Resolver {
-  identify(specifier: string, referrer?: string) { 
+  identify(specifier: string, referrer?: string) {
     if (isSpecifierStringAbsolute(specifier)) {
       return specifier;
     }

--- a/test/test-helpers/test-app.ts
+++ b/test/test-helpers/test-app.ts
@@ -7,7 +7,7 @@ export class TestApplication extends Application {
   rootElement: Simple.Element;
 }
 
-export default function buildApp(appName: string = 'test-app', options: AppBuilderOptions = {}) {
+export default function buildApp(appName = 'test-app', options: AppBuilderOptions = {}) {
   options.ApplicationClass = options.ApplicationClass || TestApplication;
   options.ComponentManager = options.ComponentManager || ComponentManager;
   return new AppBuilder(appName, options);

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,21 @@
+{
+  "rules": {
+    "curly": false,
+    "no-var-keyword": true,
+    "indent": [true, "spaces"],
+    "label-position": true,
+    "no-consecutive-blank-lines": [
+      true
+    ],
+    "no-construct": true,
+    "no-debugger": true,
+    "no-duplicate-variable": true,
+    "no-inferrable-types": [true],
+    "no-trailing-whitespace": true,
+    "no-unused-expression": true,
+    "semicolon": [true, "always"],
+    "triple-equals": true,
+    "class-name": true,
+    "no-require-imports": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1691,6 +1691,10 @@ diff@^2.2.1:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/diff/-/diff-2.2.3.tgz#60eafd0d28ee906e4e8ff0a52c1229521033bf99"
 
+diff@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
+
 dot-prop@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-3.0.0.tgz#1b708af094a49c9a0e7dbcad790aba539dac1177"
@@ -2503,7 +2507,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@7.1.1, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5:
+glob@7.1.1, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5, glob@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -4517,6 +4521,10 @@ tryor@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/tryor/-/tryor-0.1.2.tgz#8145e4ca7caff40acde3ccf946e8b8bb75b4172b"
 
+tslib@^1.6.0:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.7.1.tgz#bc8004164691923a79fe8378bbeb3da2017538ec"
+
 tslint@^3.15.1:
   version "3.15.1"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-3.15.1.tgz#da165ca93d8fdc2c086b51165ee1bacb48c98ea5"
@@ -4528,6 +4536,25 @@ tslint@^3.15.1:
     optimist "~0.6.0"
     resolve "^1.1.7"
     underscore.string "^3.3.4"
+
+tslint@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.2.0.tgz#16a2addf20cb748385f544e9a0edab086bc34114"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    colors "^1.1.2"
+    diff "^3.2.0"
+    findup-sync "~0.3.0"
+    glob "^7.1.1"
+    optimist "~0.6.0"
+    resolve "^1.3.2"
+    semver "^5.3.0"
+    tslib "^1.6.0"
+    tsutils "^1.8.0"
+
+tsutils@^1.8.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.9.1.tgz#b9f9ab44e55af9681831d5f28d0aeeaf5c750cb0"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
You can now run `npm run tslint` to see if there are any errors (this command will also run as a part of `npm run test`). To fix warnings automatically, you can use `npm run tslint:format`.

`tslint.json` is taken from [`glimmer-vm`](https://github.com/glimmerjs/glimmer-vm/blob/master/tslint.json).