### PR TITLE
Add @glimmer/compiler dependency to satisify peerDependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "tslint:format": "tslint --typecheck -c tslint.json --project tsconfig.json --fix"
   },
   "dependencies": {
+    "@glimmer/compiler": "^0.24.0-beta.4",
     "@glimmer/component": "^0.4.0",
     "@glimmer/di": "^0.1.9",
     "@glimmer/env": "^0.1.7",
@@ -37,9 +38,8 @@
   "devDependencies": {
     "@glimmer/application-test-helpers": "^0.2.1",
     "@glimmer/build": "^0.6.2",
-    "@glimmer/compiler": "^0.24.0-beta.4",
     "@glimmer/wire-format": "^0.24.0-beta.4",
-    "ember-build-utilities": "^0.1.1",
+    "ember-build-utilities": "^0.3.0",
     "ember-cli": "^2.12.0",
     "simple-dom": "^0.3.2",
     "testem": "^1.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,16 +60,6 @@
     tslint "^3.15.1"
     typescript "^2.1.5"
 
-"@glimmer/compiler@^0.23.0-alpha.11":
-  version "0.23.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.23.0-alpha.11.tgz#2f2ea9a4e20ed7f080f650a04f1d5c0385a97739"
-  dependencies:
-    "@glimmer/interfaces" "^0.23.0-alpha.11"
-    "@glimmer/syntax" "^0.23.0-alpha.11"
-    "@glimmer/util" "^0.23.0-alpha.11"
-    "@glimmer/wire-format" "^0.23.0-alpha.11"
-    simple-html-tokenizer "^0.3.0"
-
 "@glimmer/compiler@^0.24.0-beta.4":
   version "0.24.0-beta.4"
   resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.24.0-beta.4.tgz#d90a16b745eddb14c66787ed64816c3a7e220796"
@@ -101,12 +91,6 @@
 "@glimmer/env@^0.1.7":
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
-
-"@glimmer/interfaces@^0.23.0-alpha.11":
-  version "0.23.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.23.0-alpha.11.tgz#18454766efb4e545e74eb8efdf2d17eea81f1394"
-  dependencies:
-    "@glimmer/wire-format" "^0.23.0-alpha.11"
 
 "@glimmer/interfaces@^0.24.0-beta.4":
   version "0.24.0-beta.4"
@@ -151,15 +135,6 @@
     "@glimmer/util" "^0.24.0-beta.4"
     "@glimmer/wire-format" "^0.24.0-beta.4"
 
-"@glimmer/syntax@^0.23.0-alpha.11":
-  version "0.23.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.23.0-alpha.11.tgz#63da79bf932b70b3ed71a3836b712b37a6cc088c"
-  dependencies:
-    "@glimmer/interfaces" "^0.23.0-alpha.11"
-    "@glimmer/util" "^0.23.0-alpha.11"
-    handlebars "^4.0.6"
-    simple-html-tokenizer "^0.3.0"
-
 "@glimmer/syntax@^0.24.0-beta.4":
   version "0.24.0-beta.4"
   resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.24.0-beta.4.tgz#4e61c912f0f45c43175a178390630da637138e35"
@@ -169,19 +144,9 @@
     handlebars "^4.0.6"
     simple-html-tokenizer "^0.3.0"
 
-"@glimmer/util@^0.23.0-alpha.11":
-  version "0.23.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.23.0-alpha.11.tgz#8a706838684381297678cf97b6277a1a6d7668c1"
-
 "@glimmer/util@^0.24.0-beta.4":
   version "0.24.0-beta.4"
   resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.24.0-beta.4.tgz#d49063e432e2fd2af7bdc1422d3b0d849e6ce328"
-
-"@glimmer/wire-format@^0.23.0-alpha.11", "@glimmer/wire-format@^0.23.0-alpha.7":
-  version "0.23.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.23.0-alpha.11.tgz#61d7db874f37959dacb615c247424b0f5faf87b0"
-  dependencies:
-    "@glimmer/util" "^0.23.0-alpha.11"
 
 "@glimmer/wire-format@^0.24.0-beta.4":
   version "0.24.0-beta.4"
@@ -192,6 +157,10 @@
 "@types/qunit@^1.16.30":
   version "1.16.31"
   resolved "https://registry.yarnpkg.com/@types/qunit/-/qunit-1.16.31.tgz#169ba79df56f25f40556c39c544e018bb6390792"
+
+"@types/rsvp@^3.0.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@types/rsvp/-/rsvp-3.3.0.tgz#20c97372ebf32bda6a4817f7182ec672893947e6"
 
 abbrev@1:
   version "1.1.0"
@@ -559,7 +528,7 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-check-es2015-constants@^6.22.0, babel-plugin-check-es2015-constants@^6.8.0:
+babel-plugin-check-es2015-constants@^6.8.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
   dependencies:
@@ -633,13 +602,13 @@ babel-plugin-runtime@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz#bf7c7d966dd56ecd5c17fa1cb253c9acb7e54aaf"
 
-babel-plugin-transform-es2015-arrow-functions@^6.22.0, babel-plugin-transform-es2015-arrow-functions@^6.8.0:
+babel-plugin-transform-es2015-arrow-functions@^6.8.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz#452692cb711d5f79dc7f85e440ce41b9f244d221"
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-block-scoping@^6.14.0, babel-plugin-transform-es2015-block-scoping@^6.24.1:
+babel-plugin-transform-es2015-block-scoping@^6.14.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz#76c295dc3a4741b1665adfd3167215dcff32a576"
   dependencies:
@@ -649,7 +618,7 @@ babel-plugin-transform-es2015-block-scoping@^6.14.0, babel-plugin-transform-es20
     babel-types "^6.24.1"
     lodash "^4.2.0"
 
-babel-plugin-transform-es2015-classes@^6.14.0, babel-plugin-transform-es2015-classes@^6.24.1:
+babel-plugin-transform-es2015-classes@^6.14.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz#5a4c58a50c9c9461e564b4b2a3bfabc97a2584db"
   dependencies:
@@ -663,14 +632,14 @@ babel-plugin-transform-es2015-classes@^6.14.0, babel-plugin-transform-es2015-cla
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-computed-properties@^6.24.1, babel-plugin-transform-es2015-computed-properties@^6.8.0:
+babel-plugin-transform-es2015-computed-properties@^6.8.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz#6fe2a8d16895d5634f4cd999b6d3480a308159b3"
   dependencies:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-destructuring@^6.23.0, babel-plugin-transform-es2015-destructuring@^6.9.0:
+babel-plugin-transform-es2015-destructuring@^6.9.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz#997bb1f1ab967f682d2b0876fe358d60e765c56d"
   dependencies:
@@ -685,7 +654,7 @@ babel-plugin-transform-es2015-modules-commonjs@^6.18.0:
     babel-template "^6.24.1"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-parameters@^6.11.4, babel-plugin-transform-es2015-parameters@^6.24.1:
+babel-plugin-transform-es2015-parameters@^6.11.4:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz#57ac351ab49caf14a97cd13b09f66fdf0a625f2b"
   dependencies:
@@ -696,26 +665,26 @@ babel-plugin-transform-es2015-parameters@^6.11.4, babel-plugin-transform-es2015-
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-shorthand-properties@^6.24.1, babel-plugin-transform-es2015-shorthand-properties@^6.8.0:
+babel-plugin-transform-es2015-shorthand-properties@^6.8.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz#24f875d6721c87661bbd99a4622e51f14de38aa0"
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-spread@^6.22.0, babel-plugin-transform-es2015-spread@^6.8.0:
+babel-plugin-transform-es2015-spread@^6.8.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz#d6d68a99f89aedc4536c81a542e8dd9f1746f8d1"
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-template-literals@^6.22.0, babel-plugin-transform-es2015-template-literals@^6.8.0:
+babel-plugin-transform-es2015-template-literals@^6.8.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz#a84b3450f7e9f8f1f6839d6d687da84bb1236d8d"
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-proto-to-assign@^6.23.0, babel-plugin-transform-proto-to-assign@^6.9.0:
+babel-plugin-transform-proto-to-assign@^6.9.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-proto-to-assign/-/babel-plugin-transform-proto-to-assign-6.23.0.tgz#1c24951598793fc6a1d18118a11de1c36376fe2e"
   dependencies:
@@ -927,7 +896,7 @@ broccoli-babel-transpiler@^5.6.2:
     hash-for-dep "^1.0.2"
     json-stable-stringify "^1.0.0"
 
-broccoli-babel-transpiler@^6.0.0-alpha.3:
+broccoli-babel-transpiler@^6.0.0, broccoli-babel-transpiler@^6.0.0-alpha.3:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.0.0.tgz#a52c5404bf36236849da503b011fd41fe64a00a2"
   dependencies:
@@ -1177,6 +1146,19 @@ broccoli-string-replace@^0.1.1:
   dependencies:
     broccoli-persistent-filter "^1.1.5"
     minimatch "^3.0.3"
+
+broccoli-test-helper@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/broccoli-test-helper/-/broccoli-test-helper-1.1.0.tgz#7ec8a5efc33e2299b6592ca066f6f58645480bda"
+  dependencies:
+    "@types/rsvp" "^3.0.0"
+    broccoli "^1.1.0"
+    fixturify "^0.3.2"
+    fs-tree-diff "^0.5.6"
+    mktemp "^0.4.0"
+    rimraf "^2.5.4"
+    rsvp "^3.3.3"
+    walk-sync "^0.3.1"
 
 broccoli-typescript-compiler@^1.0.1:
   version "1.0.1"
@@ -1738,28 +1720,18 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-ember-build-utilities@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/ember-build-utilities/-/ember-build-utilities-0.1.1.tgz#3326d6e5fcac62eed58638fb5e2ce7331558a3ed"
+ember-build-utilities@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ember-build-utilities/-/ember-build-utilities-0.3.0.tgz#82a4dfdc6d382bfd730a8cfcf41092b56ba70de6"
   dependencies:
-    "@glimmer/compiler" "^0.23.0-alpha.11"
-    "@glimmer/wire-format" "^0.23.0-alpha.7"
-    babel-plugin-check-es2015-constants "^6.22.0"
-    babel-plugin-transform-es2015-arrow-functions "^6.22.0"
-    babel-plugin-transform-es2015-block-scoping "^6.24.1"
-    babel-plugin-transform-es2015-classes "^6.24.1"
-    babel-plugin-transform-es2015-computed-properties "^6.24.1"
-    babel-plugin-transform-es2015-destructuring "^6.23.0"
-    babel-plugin-transform-es2015-parameters "^6.24.1"
-    babel-plugin-transform-es2015-shorthand-properties "^6.24.1"
-    babel-plugin-transform-es2015-spread "^6.22.0"
-    babel-plugin-transform-es2015-template-literals "^6.22.0"
-    babel-plugin-transform-proto-to-assign "^6.23.0"
-    broccoli-babel-transpiler "^5.6.2"
+    broccoli-babel-transpiler "^6.0.0"
     broccoli-funnel "^1.1.0"
     broccoli-persistent-filter "^1.2.13"
     broccoli-rollup "^1.2.0"
+    broccoli-test-helper "^1.1.0"
+    fixturify "^0.3.3"
     lodash.defaultsdeep "^4.6.0"
+    rimraf "^2.6.1"
     semver "^5.3.0"
 
 ember-cli-broccoli-sane-watcher@^2.0.4:
@@ -2362,6 +2334,12 @@ fireworm@^0.7.0:
     lodash.debounce "^3.1.1"
     lodash.flatten "^3.0.2"
     minimatch "^3.0.2"
+
+fixturify@^0.3.2, fixturify@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/fixturify/-/fixturify-0.3.3.tgz#842eaa120564c9881e099ed06dc082a81e97fa71"
+  dependencies:
+    fs-extra "^0.30.0"
 
 for-in@^1.0.1:
   version "1.0.2"
@@ -3430,7 +3408,7 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mktemp@~0.4.0:
+mktemp@^0.4.0, mktemp@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/mktemp/-/mktemp-0.4.0.tgz#6d0515611c8a8c84e484aa2000129b98e981ff0b"
 
@@ -4030,7 +4008,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.1, rimraf@^2.5.3, rimraf@^2.6.1:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.1, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:


### PR DESCRIPTION
ember-build-utilities expects to be able to `require('@glimmer/compiler')` and get the right version. This PR moves `@glimmer/compiler` into `dependencies`, and updates ember-build-utilities to the latest version.