### PR TITLE
WIP: `renderComponent` args

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -14,8 +14,8 @@ import {
   UpdatableReference
 } from '@glimmer/object-reference';
 import {
-  Option,
-  Dict
+  Dict,
+  Maybe
 } from '@glimmer/util';
 import {
   Simple
@@ -47,8 +47,8 @@ export class AppRoot {
     private index: number,
     public component: string,
     public parent: Simple.Node,
-    public nextSibling: Option<Simple.Node>,
-    public args: Args
+    public nextSibling: Maybe<Simple.Node>,
+    public args: Maybe<Args>
   ) {}
 
   get id(): string {
@@ -57,7 +57,7 @@ export class AppRoot {
 }
 
 export interface RenderComponentOptions {
-  nextSibling?: Option<Simple.Node>;
+  nextSibling?: Simple.Node;
   args?: Args;
 }
 

--- a/src/application.ts
+++ b/src/application.ts
@@ -14,7 +14,6 @@ import {
   UpdatableReference
 } from '@glimmer/object-reference';
 import {
-  Dict,
   Maybe
 } from '@glimmer/util';
 import {
@@ -24,6 +23,7 @@ import ApplicationRegistry from './application-registry';
 import DynamicScope from './dynamic-scope';
 import Environment from './environment';
 import mainTemplate from './templates/main';
+import { Args } from './args';
 
 function NOOP() {}
 
@@ -37,8 +37,6 @@ export interface Initializer {
   name?: string;
   initialize(registry: RegistryWriter): void;
 }
-
-export type Args = Dict<any>;
 
 export class AppRoot {
   public revision = 0;
@@ -68,14 +66,9 @@ export class RenderComponentResult {
     this.root = this.app['_roots'][this.rootIndex];
   }
 
-  updateArgs(newArgs: Args): void {
-    this.root.args = newArgs;
-    this.update();
-    this.app.scheduleRerender();
-  }
-
-  private update() {
+  update() {
     this.root.revision++;
+    this.app.scheduleRerender();
   }
 }
 

--- a/src/application.ts
+++ b/src/application.ts
@@ -16,7 +16,8 @@ import {
   UpdatableReference
 } from '@glimmer/object-reference';
 import {
-  Option
+  Option,
+  Dict
 } from '@glimmer/util';
 import {
   Simple
@@ -44,6 +45,12 @@ export interface AppRoot {
   component: string | ComponentDefinition<Component>;
   parent: Simple.Node;
   nextSibling: Option<Simple.Node>;
+  args?: Dict<any>;
+}
+
+export interface RenderComponentOptions {
+  nextSibling?: Option<Simple.Node>;
+  args?: Dict<any>;
 }
 
 export default class Application implements Owner {
@@ -158,8 +165,10 @@ export default class Application implements Owner {
     this._rendered = true;
   }
 
-  renderComponent(component: string | ComponentDefinition<Component>, parent: Simple.Node, nextSibling: Option<Simple.Node> = null): void {
-    this._roots.push({ id: this._rootsIndex++, component, parent, nextSibling });
+  renderComponent(component: string, parent: Simple.Node, options: RenderComponentOptions = {}): void {
+    let { nextSibling, args } = options;
+
+    this._roots.push({ id: this._rootsIndex++, component, parent, nextSibling, args });
     this.scheduleRerender();
   }
 

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,0 +1,52 @@
+import {
+  Dict,
+  Opaque
+} from '@glimmer/util';
+import {
+  VersionedPathReference,
+  TagWrapper,
+  DirtyableTag
+} from '@glimmer/reference';
+import {
+  PreparedArguments
+} from '@glimmer/runtime';
+
+export type Args = PreparedArguments;
+export type RawNamedArgs = Dict<any>;
+
+export default class UpdatableArgReference implements VersionedPathReference<Opaque> {
+  public tag: TagWrapper<DirtyableTag>;
+
+  constructor(public _value: Opaque) {
+    this.tag = DirtyableTag.create();
+  }
+
+  get(key: string): VersionedPathReference<Opaque> {
+    let value = this.value();
+
+    if (!value) {
+      return new UpdatableArgReference(value);
+    }
+
+    return new UpdatableArgReference(value[key]);
+  }
+
+  value(): Opaque {
+    return this._value;
+  }
+
+  set(newValue): void {
+    this._value = newValue;
+    this.tag.inner.dirty();
+  }
+}
+
+export function prepareNamedArgs(rawArgs: RawNamedArgs): Dict<UpdatableArgReference> {
+  let named: Dict<UpdatableArgReference> = {};
+
+  Object.keys(rawArgs).forEach(key => {
+    named[key] = new UpdatableArgReference(rawArgs[key]) as any;
+  });
+
+  return named;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
-export { default, ApplicationOptions, Initializer, AppRoot } from './application';
+export { default, ApplicationOptions, Initializer, AppRoot, RenderComponentOptions, RenderComponentResult } from './application';
 export { default as Environment } from './environment';
+export { default as UpdatableArgReference, Args, prepareNamedArgs } from './args';

--- a/src/templates/main.hbs
+++ b/src/templates/main.hbs
@@ -1,5 +1,5 @@
 {{#each roots key="id" as |root|~}}
   {{~#-in-element root.parent nextSibling=root.nextSibling~}}
-    {{~component root.component~}}
+    {{~component root.component root.args~}}
   {{~/-in-element~}}
 {{~/each~}}

--- a/test/render-component-test.ts
+++ b/test/render-component-test.ts
@@ -129,7 +129,7 @@ test('renders multiple components in the same container in particular places', a
 });
 
 test('accepts args', async function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
   let containerElement = document.createElement('div');
 
@@ -139,9 +139,15 @@ test('accepts args', async function(assert) {
 
   let args = { name: 'Glimmer' };
 
-  app.renderComponent('hello-world', containerElement, { args });
+  let result = app.renderComponent('hello-world', containerElement, { args });
 
   await didRender(app);
 
   assert.equal(containerElement.innerHTML, '<hello-world>Hello Glimmer!</hello-world>');
+
+  result.updateArgs({ name: 'Robbie' });
+
+  await didRender(app);
+
+  assert.equal(containerElement.innerHTML, '<hello-world>Hello Robbie!</hello-world>');
 });

--- a/test/render-component-test.ts
+++ b/test/render-component-test.ts
@@ -1,5 +1,7 @@
 import buildApp from './test-helpers/test-app';
 import { didRender } from '@glimmer/application-test-helpers';
+import { EMPTY_ARRAY } from '@glimmer/util';
+import { prepareNamedArgs } from '../src/args';
 
 const { module, test } = QUnit;
 
@@ -137,15 +139,20 @@ test('accepts args', async function(assert) {
     .template('hello-world', `<hello-world>Hello {{@name}}!</hello-world>`)
     .boot();
 
-  let args = { name: 'Glimmer' };
-
+  let positional = EMPTY_ARRAY;
+  let named = prepareNamedArgs({ name: 'Glimmer' });
+  let args = {
+    positional,
+    named
+  };
   let result = app.renderComponent('hello-world', containerElement, { args });
 
   await didRender(app);
 
   assert.equal(containerElement.innerHTML, '<hello-world>Hello Glimmer!</hello-world>');
 
-  result.updateArgs({ name: 'Robbie' });
+  named.name.set('Robbie');
+  result.update();
 
   await didRender(app);
 

--- a/test/render-component-test.ts
+++ b/test/render-component-test.ts
@@ -60,7 +60,7 @@ test('renders a component before a given sibling', async function(assert) {
 
   assert.equal(containerElement.innerHTML, '<p></p><aside></aside>');
 
-  app.renderComponent('hello-world', containerElement, nextSibling);
+  app.renderComponent('hello-world', containerElement, { nextSibling });
 
   await didRender(app);
 
@@ -121,9 +121,27 @@ test('renders multiple components in the same container in particular places', a
   assert.equal(containerElement.innerHTML, '<aside></aside>');
 
   app.renderComponent('hello-world', containerElement);
-  app.renderComponent('hello-robbie', containerElement, nextSibling);
+  app.renderComponent('hello-robbie', containerElement, { nextSibling });
 
   await didRender(app);
 
   assert.equal(containerElement.innerHTML, '<h1>Hello Robbie!</h1><aside></aside><h1>Hello Glimmer!</h1>');
+});
+
+test('accepts args', async function(assert) {
+  assert.expect(1);
+
+  let containerElement = document.createElement('div');
+
+  let app = buildApp()
+    .template('hello-world', `<hello-world>Hello {{@name}}!</hello-world>`)
+    .boot();
+
+  let args = { name: 'Glimmer' };
+
+  app.renderComponent('hello-world', containerElement, { args });
+
+  await didRender(app);
+
+  assert.equal(containerElement.innerHTML, '<hello-world>Hello Glimmer!</hello-world>');
 });


### PR DESCRIPTION
New signature:

```ts
renderComponent(
  component: string,
  parent: Simple.Node,
  options: RenderComponentOptions = {}
): RenderComponentResult
```

Given:

```ts
// From @glimmer/runtime
interface PreparedArguments {
  positional: Array<VersionedPathReference<Opaque>>;
  named: Dict<VersionedPathReference<Opaque>>;
}

type Args = PreparedArguments;

interface RenderComponentOptions {
  nextSibling?: Option<Simple.Node>;
  args?: Args;
}

interface RenderComponentResult {
  update(): void;
}
```

Also ships with some helpful stuff to make this API easier to use:

```ts
import { EMPTY_ARRAY } from '@glimmer/util';
import { prepareNamedArgs } from '@glimmer/application';

// ...

let positional = EMPTY_ARRAY;
let named = prepareNamedArgs({ greeting: 'Hello' });
let result = app.renderComponent('greet-person', containerElement, {
  args: { positional, named }
});

named.greeting.set('Olá');
result.update();
```

## To-do:

- [x] Args with initial render
- [x] Updating args and rerendering
- [x] Publish https://github.com/glimmerjs/glimmer-application-test-helpers/pull/5
- [ ] Publish https://github.com/glimmerjs/glimmer-component/pull/63
- [ ] Bump `@glimmer/component`