### PR TITLE
Allow custom elements

### DIFF
--- a/test/environment-test.ts
+++ b/test/environment-test.ts
@@ -77,6 +77,16 @@ test('can render a component with the component helper', async function(assert) 
   assert.equal(root.innerText, 'Hello Glimmer!');
 });
 
+test('custom elements are rendered', function(assert) {
+  let app = buildApp()
+    .template('main', '<hello-world>foo</hello-world>')
+    .boot();
+
+  let serializedHTML = serializer.serialize(app.rootElement);
+
+  assert.equal(serializedHTML, '<div><hello-world>foo</hello-world></div>');
+});
+
 test('components without a template raise an error', function(assert) {
   class HelloWorldComponent extends Component {
     debugName: 'hello-world';


### PR DESCRIPTION
We were throwing an error when a component wasn't found in `getComponentDefinition`. Instead, this returns `false` from `hasComponentDefinition` if there is no component.