### PR TITLE
Expose root data to component managers

### DIFF
--- a/src/templates/main.hbs
+++ b/src/templates/main.hbs
@@ -1,5 +1,7 @@
 {{#each roots key="id" as |root|~}}
   {{~#-in-element root.parent nextSibling=root.nextSibling~}}
-    {{~component root.component~}}
+    {{~#-with-dynamic-vars _parentElement=root.parent~}}
+      {{~component root.component~}}
+    {{~/-with-dynamic-vars~}}
   {{~/-in-element~}}
 {{~/each~}}

--- a/test/application-test.ts
+++ b/test/application-test.ts
@@ -1,6 +1,8 @@
 import Application from '../src/application';
+import buildApp from './test-helpers/test-app';
 import { BlankResolver } from './test-helpers/resolvers';
 import { Document } from 'simple-dom';
+import { ComponentManager } from '@glimmer/component';
 
 const { module, test } = QUnit;
 
@@ -20,4 +22,27 @@ test('accepts options for rootName, resolver and document', function(assert) {
   let customDocument = new Document();
   app = new Application({ rootName: 'app', resolver, document: customDocument });
   assert.equal(app.document, customDocument);
+});
+
+test('makes parent element available to the component manager', function(assert) {
+  assert.expect(1);
+
+  let parentElement;
+
+  class FancyComponentManager extends ComponentManager {
+    static create(options) {
+      return new this(options);
+    }
+    create(env, def, args, dynamicScope) {
+      parentElement = dynamicScope.get('_parentElement').value();
+
+      return super.create(env, def, args);
+    }
+  }
+
+  let app = buildApp('test-app', { ComponentManager: FancyComponentManager })
+    .template('main', '<foo-bar>baz</foo-bar>')
+    .boot();
+
+  assert.equal(parentElement.outerHTML, '<div><foo-bar>baz</foo-bar></div>');
 });


### PR DESCRIPTION
In my quest to improve the web component story with Glimmer I've found utility in exposing "root component" data to component managers. Root component data is comprised of:

- The root id (just an index at the moment)
- The component (just a string representing the name right now, but in the future we can easily support accepting the component definition)
- The parent element (what to render into)
- The next sibling (for inserting instead of appending; this is optional)

The parent element is what I am most interested in. In the case of web components, this is the element whose shadow dom we [render the fragment into](https://github.com/glimmerjs/glimmer-web-component/pull/18/commits/2b42308e48898fd72fd13f9d9734380e2a7bbc47#diff-94a0776a34741fcab440ce7cbd4691d8R35). The element can also be found via the `bounds` argument in the `didRenderLayout` component manager hook, but that is too late if we want to use element properties in the component during render.

Exposing the `root` object like this opens up the door for future utility if we want to add fields to the root object.