### PR TITLE
-in-element should not overlap

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -132,7 +132,7 @@ export default class Application implements Owner {
     let mainLayout = templateFactory(mainTemplate).create(this.env);
     let self = new UpdatableReference({ roots: this._roots });
     let doc = this.document as Document; // TODO FixReification
-    let parentNode = doc.body;
+    let parentNode = doc.head;
     let dynamicScope = new DynamicScope();
     let templateIterator = mainLayout.render({ self, parentNode, dynamicScope });
     let result;


### PR DESCRIPTION
## What is going on here?

The top level render with `-in-element` just happened to work but is not really reflective of how it should work. What I mean by this is that `doc.body` is going to contain the DOM nodes that are the remote roots. This is like a recursive render call where our root node is the `body` but all the remote elements are children of the body. `-in-element` is intended to be used such that there is no overlap from where the application is rendered and where the remote roots are at.

Since there is no DOM emitted by the top level template and is merely a mechanism for splatting out components we should be able to just use the `head` as the root element passed to `render`.

## Why Change This

As I was working on implementing rehydration for `in-element` it was pretty clear that this would run into issues where serialized elements would get blown away upon rehydrating because hydration occurs from the `parentNode` down. This meant that when we ran across a "remote" e.g. `<div id="app"></div>` it did not know what to do as remotes are supposed to be outside of the entry node and jump to them to fill them in.


## Other Solutions
It is likely that we could just use a `DocumentFragment` here, but that creates a leak as the fragment will never be appended. Likely ok, but by spec we should always have a `head` element to use.