### PR TITLE
Monorepo preparation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,5 @@
 export { default, ApplicationOptions, Initializer, AppRoot } from './application';
-export { default as Environment } from './environment';
+export { default as Environment, EnvironmentOptions } from './environment';
+export { default as ApplicationRegistry } from './application-registry';
+export { default as Iterable } from './iterable';
+export { debugInfoForReference } from './helpers/action';

--- a/test/action-test.ts
+++ b/test/action-test.ts
@@ -1,7 +1,7 @@
 import Component, { tracked } from '@glimmer/component';
 import buildApp from './test-helpers/test-app';
 import { didRender } from '@glimmer/application-test-helpers';
-import { debugInfoForReference } from '../src/helpers/action';
+import { debugInfoForReference } from '../src/index';
 
 const { module, test } = QUnit;
 

--- a/test/application-as-owner-test.ts
+++ b/test/application-as-owner-test.ts
@@ -1,4 +1,4 @@
-import Application from '../src/application';
+import Application from '../src/index';
 import { Resolver, getOwner, isSpecifierStringAbsolute } from '@glimmer/di';
 import { BlankResolver } from './test-helpers/resolvers';
 

--- a/test/application-registry-test.ts
+++ b/test/application-registry-test.ts
@@ -1,4 +1,4 @@
-import ApplicationRegistry from '../src/application-registry';
+import { ApplicationRegistry } from '../src/index';
 import { Registry } from '@glimmer/di';
 import { BlankResolver } from './test-helpers/resolvers';
 

--- a/test/application-test.ts
+++ b/test/application-test.ts
@@ -1,4 +1,4 @@
-import Application from '../src/application';
+import Application from '../src/index';
 import { BlankResolver } from './test-helpers/resolvers';
 import { Document } from 'simple-dom';
 

--- a/test/environment-test.ts
+++ b/test/environment-test.ts
@@ -1,6 +1,6 @@
 import { getOwner, setOwner, Owner } from '@glimmer/di';
 import { DOMTreeConstruction } from '@glimmer/runtime';
-import Environment, { EnvironmentOptions } from '../src/environment';
+import { Environment, EnvironmentOptions } from '../src/index';
 import Component from '@glimmer/component';
 import buildApp from './test-helpers/test-app';
 import { didRender } from '@glimmer/application-test-helpers';

--- a/test/initializers-test.ts
+++ b/test/initializers-test.ts
@@ -1,4 +1,4 @@
-import Application from '../src/application';
+import Application from '../src/index';
 import { BlankResolver } from './test-helpers/resolvers';
 
 const { module, test } = QUnit;

--- a/test/iterable-test.ts
+++ b/test/iterable-test.ts
@@ -1,4 +1,4 @@
-import Iterable from '../src/iterable';
+import { Iterable } from '../src/index';
 
 const { module, test } = QUnit;
 

--- a/test/test-helpers/test-app.ts
+++ b/test/test-helpers/test-app.ts
@@ -1,10 +1,10 @@
-import Application from '../../src/application';
-import { Simple } from '@glimmer/runtime';
+import Application from '../../src/index';
+import { Element } from 'simple-dom';
 import { AppBuilder, AppBuilderOptions } from '@glimmer/application-test-helpers';
 import { ComponentManager } from '@glimmer/component';
 
 export class TestApplication extends Application {
-  rootElement: Simple.Element;
+  rootElement: Element;
 }
 
 export default function buildApp(appName = 'test-app', options: AppBuilderOptions = {}) {

--- a/tslint.json
+++ b/tslint.json
@@ -1,21 +1,21 @@
 {
   "rules": {
     "curly": false,
-      "no-var-keyword": true,
-      "indent": [true, "spaces"],
-      "label-position": true,
-      "no-consecutive-blank-lines": [
-        true
-      ],
-      "no-construct": true,
-      "no-debugger": true,
-      "no-duplicate-variable": true,
-      "no-inferrable-types": [true],
-      "no-trailing-whitespace": true,
-      "no-unused-expression": true,
-      "semicolon": [true, "always"],
-      "triple-equals": true,
-      "class-name": true,
-      "no-require-imports": true
+    "no-var-keyword": true,
+    "indent": [true, "spaces"],
+    "label-position": true,
+    "no-consecutive-blank-lines": [
+      true
+    ],
+    "no-construct": true,
+    "no-debugger": true,
+    "no-duplicate-variable": true,
+    "no-inferrable-types": [true],
+    "no-trailing-whitespace": true,
+    "no-unused-expression": true,
+    "semicolon": [true, "always"],
+    "triple-equals": true,
+    "class-name": true,
+    "no-require-imports": true
   }
 }


### PR DESCRIPTION
This PR makes two changes in preparation of including @glimmer/component in a glimmer.js monorepo:

1. Tests import from the package root (`index.js`) rather than nested modules. This facilitates running tests against production builds of packages, where internal modules get hoisted into variable scope and any path information is loss. (That is, you can only `require('@glimmer/application')`, not `require('@glimmer/application/src/environment')`.)
2. Updates tslint.json to be the same as glimmer-vm.